### PR TITLE
allow for images with a static preset to scroll

### DIFF
--- a/src/modules/react-reconciler/Atlas.tsx
+++ b/src/modules/react-reconciler/Atlas.tsx
@@ -448,7 +448,7 @@ export const Atlas: React.FC<
   return (
     <Container
       ref={ref}
-      className={['atlas', hideInlineStyle ? '' : `atlas-width-${widthClassName}`, containerClassName, className]
+      className={['atlas', hideInlineStyle ? '' : `atlas-width-${widthClassName}`, containerClassName, className, `atlas-${presetName}`]
         .filter(Boolean)
         .join(' ')
         .trim()}
@@ -517,6 +517,7 @@ export const Atlas: React.FC<
         .atlas-canvas { flex: 1 1 0px; }
         .atlas-canvas:focus, .atlas-static-container:focus { outline: none }
         .atlas-canvas:focus-visible, .atlas-canvas-container:focus-visible { outline: var(--atlas-focus, 2px solid darkorange) }
+        .atlas-static-preset { touch-action: inherit; }
         .atlas-static-container { position: relative; overflow: hidden; flex: 1 1 0px; }
         .atlas-overlay { position: absolute; top: 0; left: 0; pointer-events: none; overflow: hidden; }
         .atlas-static-image { position: absolute; pointer-events: none; user-select: none; transform-origin: 0px 0px; }

--- a/stories/homepage.stories.tsx
+++ b/stories/homepage.stories.tsx
@@ -134,6 +134,46 @@ export const HTMLPerformance = () => {
     </>
   );
 };
+export const StaticRendererPreset = () => {
+  const [c, setC] = useState(false);
+  const boxes = [];
+  const number = 40;
+  const size = 100;
+  for (let i = 0; i < number; i++) {
+    for (let j = 0; j < number; j++) {
+      boxes.push(
+        <worldObject key={`${i}--${j}`} id={`${i}-${j}`} width={size} height={size} x={i * size} y={j * size}>
+          <box
+            className={c ? undefined : (j + i) % 2 ? 'red' : 'blue'}
+            target={{ x: 0, y: 0, width: size, height: size }}
+            style={c ? { backgroundColor: (j + i) % 2 ? 'red' : 'blue' } : undefined}
+          />
+        </worldObject>
+      );
+    }
+  }
+
+  return (
+    <>
+      <button onClick={() => setC((t) => !t)}>current: {c ? 'canvas' : 'html'}</button>
+      <Atlas
+        width={400}
+        height={400}
+        key={c ? 'a' : 'b'}
+        renderPreset={['static-preset', { canvasBox: c }]}
+        onCreated={(rt) => rt.runtime?.world.gotoRegion({ x: 0, y: 0, width: 300, height: 300, immediate: true })}
+      >
+        {boxes}
+      </Atlas>
+      <style>
+        {`
+          .blue{background: blue}
+          .red{background: red}
+        `}
+      </style>
+    </>
+  );
+};
 
 export const RawTexture = () => {
   const video = useRef<HTMLVideoElement>(null);


### PR DESCRIPTION
outlining a potential solution for https://github.com/digirati-co-uk/iiif-canvas-panel/issues/232 based on my very basic understanding of the code. Apologies if I've messed things up.

The `touch-action: none` css property is set on the `.atlas` class indescriminantly, causing it to consume all touch events.  For cases where Atlas is intended to ‘own’ those events that’s fine. But, in the static mode, the window/document should own those events.

By exposing the render preset as a class, we can use that as a selector, and thus return the touch-events property to the default by setting it to inherit