### PR TITLE
add imageIdsLoaded array for deduping

### DIFF
--- a/src/modules/canvas-renderer/canvas-renderer.ts
+++ b/src/modules/canvas-renderer/canvas-renderer.ts
@@ -175,7 +175,7 @@ export class CanvasRenderer implements Renderer {
     // this.ctx.translate(-this.canvas.width / 2, -this.canvas.height / 2);
     this.frameIsRendering = false;
     // After we've rendered, we'll set the pending and loading to correct values.
-    this.imagesPending = this.imagesPending - this.imagesLoaded;
+    this.imagesPending = Math.min(0, this.imagesPending - this.imagesLoaded);
     this.imagesLoaded = 0;
     if (!this.loadingQueueOrdered /*&& this.loadingQueue.length > this.parallelTasks*/) {
       this.loadingQueue = this.loadingQueue.sort((a, b) => {

--- a/src/modules/canvas-renderer/canvas-renderer.ts
+++ b/src/modules/canvas-renderer/canvas-renderer.ts
@@ -71,6 +71,11 @@ export class CanvasRenderer implements Renderer {
   imagesLoaded = 0;
 
   /**
+   * The ids of the completed images, use to dedupe
+   */
+  imageIdsLoaded: string[] = [];
+
+  /**
    * Can be used to avoid or stop work when frame is or isn't rendering outside of the main loop.
    */
   frameIsRendering = false;
@@ -694,7 +699,10 @@ export class CanvasRenderer implements Renderer {
                 distance: priority,
                 task: () => {
                   return new Promise<void>((innerResolve) => {
-                    this.imagesLoaded++;
+                    if (!this.imageIdsLoaded.includes(id)) {
+                      this.imagesLoaded++;
+                      this.imageIdsLoaded.push(id);
+                    }
                     imageBuffer.loaded.push(index);
                     if (imageBuffer.loaded.length === imageBuffer.indices.length) {
                       imageBuffer.loading = false;


### PR DESCRIPTION
This adds the image ids to an array `imageIdsLoaded` which is then evaluated in`schedulePaintToCanvas` before incrementing `imagesLoaded` to avoid a scenario where a repeated calls to the method for the same image can result in a negative value for the latter, leaving the atlas canvas in a state where the opacity style never updates to 1 as observed in https://github.com/atlas-viewer/atlas/issues/49.