### PR TITLE
fix imagesPending assignment

### DIFF
--- a/src/modules/canvas-renderer/canvas-renderer.ts
+++ b/src/modules/canvas-renderer/canvas-renderer.ts
@@ -175,7 +175,7 @@ export class CanvasRenderer implements Renderer {
     // this.ctx.translate(-this.canvas.width / 2, -this.canvas.height / 2);
     this.frameIsRendering = false;
     // After we've rendered, we'll set the pending and loading to correct values.
-    this.imagesPending = Math.min(0, this.imagesPending - this.imagesLoaded);
+    this.imagesPending = Math.max(0, this.imagesPending - this.imagesLoaded);
     this.imagesLoaded = 0;
     if (!this.loadingQueueOrdered /*&& this.loadingQueue.length > this.parallelTasks*/) {
       this.loadingQueue = this.loadingQueue.sort((a, b) => {


### PR DESCRIPTION
@stephenwf I looked at the issue in the CanvasPanel update and immediately realized that I had failed to push this commit at the end - this should be `Math.max` otherwise `imagesPending` is always going to be 0 and nothing will render.