### PR TITLE
Add alternate touch event models

### DIFF
--- a/src/modules/browser-event-manager/browser-event-manager.ts
+++ b/src/modules/browser-event-manager/browser-event-manager.ts
@@ -71,6 +71,7 @@ export class BrowserEventManager {
       }
     });
 
+    // this is necessary for CavnasPanel to initialize the event listener
     this.activateEvents();
   }
 
@@ -81,7 +82,6 @@ export class BrowserEventManager {
 
   layoutSubscriber(type: string) {
     if (type === 'event-activation' && this.listening == false) {
-      console.log(`${this.listening} ${type}`);
       this.activateEvents();
     }
   }
@@ -93,7 +93,6 @@ export class BrowserEventManager {
   }
 
   activateEvents() {
-    console.log('activating events');
     this.listening = true;
     this.element.addEventListener('pointermove', this._realPointerMove);
     this.element.addEventListener('pointerup', this.onPointerUp);

--- a/src/modules/browser-event-manager/browser-event-manager.ts
+++ b/src/modules/browser-event-manager/browser-event-manager.ts
@@ -15,7 +15,7 @@ export class BrowserEventManager {
   activatedEvents: string[] = [];
   eventHandlers: [string, any][] = [];
   bounds: DOMRect;
-
+  listening: boolean;
   static eventPool = {
     atlas: { x: 0, y: 0 },
   };
@@ -50,6 +50,7 @@ export class BrowserEventManager {
     this.runtime = runtime;
     this.unsubscribe = runtime.world.addLayoutSubscriber(this.layoutSubscriber.bind(this));
     this.bounds = element.getBoundingClientRect();
+    this.listening = false;
     this.options = {
       simulationRate: 0,
       ...(options || {}),
@@ -69,9 +70,6 @@ export class BrowserEventManager {
         this.onPointerMove(this.pointerMoveEvent);
       }
     });
-
-    // @todo temp.
-    this.activateEvents();
   }
 
   updateBounds() {
@@ -80,7 +78,7 @@ export class BrowserEventManager {
   }
 
   layoutSubscriber(type: string) {
-    if (type === 'event-activation') {
+    if (type === 'event-activation' && this.listening == false) {
       this.activateEvents();
     }
   }
@@ -92,6 +90,7 @@ export class BrowserEventManager {
   }
 
   activateEvents() {
+    this.listening = true;
     this.element.addEventListener('pointermove', this._realPointerMove);
     this.element.addEventListener('pointerup', this.onPointerUp);
     this.element.addEventListener('pointerdown', this.onPointerDown);
@@ -292,6 +291,25 @@ export class BrowserEventManager {
   }
 
   stop() {
+    this.listening = false;
+    this.element.removeEventListener('pointermove', this._realPointerMove);
+    this.element.removeEventListener('pointerup', this.onPointerUp);
+    this.element.removeEventListener('pointerdown', this.onPointerDown);
+
+    // Normal events.
+    this.element.removeEventListener('mousedown', this.onPointerEvent);
+    this.element.removeEventListener('mouseup', this.onPointerEvent);
+    this.element.removeEventListener('pointercancel', this.onPointerEvent);
+
+    // Edge-cases
+    this.element.removeEventListener('wheel', this.onWheelEvent);
+
+    // Touch events.
+    this.element.removeEventListener('touchstart', this.onTouchEvent);
+    this.element.removeEventListener('touchcancel', this.onTouchEvent);
+    this.element.removeEventListener('touchend', this.onTouchEvent);
+    this.element.removeEventListener('touchmove', this.onTouchEvent);
+
     // Unbind all events.
     this.unsubscribe();
     for (const [event, handler] of this.eventHandlers) {

--- a/src/modules/browser-event-manager/browser-event-manager.ts
+++ b/src/modules/browser-event-manager/browser-event-manager.ts
@@ -70,6 +70,8 @@ export class BrowserEventManager {
         this.onPointerMove(this.pointerMoveEvent);
       }
     });
+
+    this.activateEvents();
   }
 
   updateBounds() {
@@ -79,6 +81,7 @@ export class BrowserEventManager {
 
   layoutSubscriber(type: string) {
     if (type === 'event-activation' && this.listening == false) {
+      console.log(`${this.listening} ${type}`);
       this.activateEvents();
     }
   }
@@ -90,6 +93,7 @@ export class BrowserEventManager {
   }
 
   activateEvents() {
+    console.log('activating events');
     this.listening = true;
     this.element.addEventListener('pointermove', this._realPointerMove);
     this.element.addEventListener('pointerup', this.onPointerUp);

--- a/src/modules/popmotion-controller/popmotion-controller.ts
+++ b/src/modules/popmotion-controller/popmotion-controller.ts
@@ -460,7 +460,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
 
         runtime.world.removeEventListener('mousemove', onMouseMove);
         if (parentElement) {
-          parentElement.removeEventListener('touchmove', onMouseMove);
+          (parentElement as any).removeEventListener('touchmove', onMouseMove);
         }
         if (enableClickToZoom) {
           runtime.world.removeEventListener('click', onClick);

--- a/src/modules/popmotion-controller/popmotion-controller.ts
+++ b/src/modules/popmotion-controller/popmotion-controller.ts
@@ -59,7 +59,7 @@ export const defaultConfig: Required<PopmotionControllerConfig> = {
   enableClickToZoom: true,
   ignoreSingleFingerTouch: false,
   enablePanOnWait: false,
-  requireMetaKeyForWheelZoom: true,
+  requireMetaKeyForWheelZoom: false,
   panOnWaitDelay: 40,
   onPanInSketchMode: () => {
     // no-op

--- a/src/modules/popmotion-controller/popmotion-controller.ts
+++ b/src/modules/popmotion-controller/popmotion-controller.ts
@@ -392,11 +392,11 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
       // runtime.world.addEventListener('pointermove', pointerMove);
 
       runtime.world.addEventListener('mouseup', onMouseUp);
-      window.addEventListener('touchend', onMouseUp);
+      runtime.world.addEventListener('touchend', onMouseUp);
       runtime.world.addEventListener('touchstart', onTouchStart);
       runtime.world.addEventListener('mousedown', onMouseDown);
 
-      runtime.world.addEventListener('touchend', onWindowMouseUp);
+      window.addEventListener('touchend', onWindowMouseUp);
       window.addEventListener('mouseup', onWindowMouseUp);
 
       window.addEventListener('mousemove', onMouseMove);

--- a/src/modules/popmotion-controller/popmotion-controller.ts
+++ b/src/modules/popmotion-controller/popmotion-controller.ts
@@ -188,10 +188,14 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
       //   }
       // }
 
+      /**
+       * Resets the event state after the gesture of behavior has finished
+       */
       function resetState() {
         currentDistance = 0;
         intent = '';
         setDataAttribute();
+        setDataAttribute(undefined, 'notice');
         touchStartTime = 0;
       }
 
@@ -264,6 +268,12 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         }
       }
 
+      /**
+       * Sets a data attribute to expose the current intent/behavior/note to the user
+       *
+       * @param value {string} - the data-attribute value
+       * @param dataAttribute {string} - the data-attribute name
+       */
       function setDataAttribute(value?: string, dataAttribute = 'intent') {
         if (parentElement) {
           parentElement.dataset[dataAttribute] = value;

--- a/src/modules/popmotion-controller/popmotion-controller.ts
+++ b/src/modules/popmotion-controller/popmotion-controller.ts
@@ -27,9 +27,9 @@ export type PopmotionControllerConfig = {
   devicePixelRatio?: number;
   enableWheel?: boolean;
   enableClickToZoom?: boolean;
-  debug?: boolean;
   ignoreSingleFingerTouch?: boolean;
   enablePanOnWait?: boolean;
+  requireMetaKeyForWheelZoom?: boolean;
   panOnWaitDelay?: number;
   parentElement?: HTMLElement | null;
   onPanInSketchMode?: () => void;
@@ -57,10 +57,10 @@ export const defaultConfig: Required<PopmotionControllerConfig> = {
   // Flags
   enableWheel: true,
   enableClickToZoom: true,
-  ignoreSingleFingerTouch: true,
-  enablePanOnWait: true,
+  ignoreSingleFingerTouch: false,
+  enablePanOnWait: false,
+  requireMetaKeyForWheelZoom: true,
   panOnWaitDelay: 40,
-  debug: false,
   onPanInSketchMode: () => {
     // no-op
   },
@@ -77,8 +77,8 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         ignoreSingleFingerTouch,
         enablePanOnWait,
         panOnWaitDelay,
-        debug,
         parentElement,
+        requireMetaKeyForWheelZoom,
       } = {
         ...defaultConfig,
         ...config,
@@ -115,78 +115,78 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
       //  el.onpointercancel = pointerup_handler;
       //  el.onpointerout = pointerup_handler;
       //  el.onpointerleave = pointerup_handler;
-      const eventCache: PointerEvent[] = [];
-      const atlasPointsCache: any[] = [];
-      let prevDiff = -1;
-      function removeFromEventCache(e: PointerEvent) {
-        // Remove this event from the target's cache
-        for (let i = 0; i < eventCache.length; i++) {
-          if (eventCache[i].pointerId == e.pointerId) {
-            eventCache.splice(i, 1);
-            atlasPointsCache.splice(i, 1);
-            break;
-          }
-        }
-      }
+      // const eventCache: PointerEvent[] = [];
+      // const atlasPointsCache: any[] = [];
+      // let prevDiff = -1;
+      // function removeFromEventCache(e: PointerEvent) {
+      //   // Remove this event from the target's cache
+      //   for (let i = 0; i < eventCache.length; i++) {
+      //     if (eventCache[i].pointerId == e.pointerId) {
+      //       eventCache.splice(i, 1);
+      //       atlasPointsCache.splice(i, 1);
+      //       break;
+      //     }
+      //   }
+      // }
 
-      function pointerDown(e: PointerEvent) {
-        eventCache.push(e);
-        atlasPointsCache.push({ ...((e as any).atlas || {}) });
-      }
-      function pointerMove(e: PointerEvent) {
-        for (let i = 0; i < eventCache.length; i++) {
-          if (e.pointerId == eventCache[i].pointerId) {
-            eventCache[i] = e;
-            atlasPointsCache[i] = { ...((e as any).atlas || {}) };
-            break;
-          }
-        }
-        if (eventCache.length == 2) {
-          const curDiff = Math.abs(eventCache[0].clientX - eventCache[1].clientX);
+      // function pointerDown(e: PointerEvent) {
+      //   eventCache.push(e);
+      //   atlasPointsCache.push({ ...((e as any).atlas || {}) });
+      // }
+      // function pointerMove(e: PointerEvent) {
+      //   for (let i = 0; i < eventCache.length; i++) {
+      //     if (e.pointerId == eventCache[i].pointerId) {
+      //       eventCache[i] = e;
+      //       atlasPointsCache[i] = { ...((e as any).atlas || {}) };
+      //       break;
+      //     }
+      //   }
+      //   if (eventCache.length == 2) {
+      //     const curDiff = Math.abs(eventCache[0].clientX - eventCache[1].clientX);
 
-          // - - 2 - - 6- - - - 10
-          const xDiff =
-            atlasPointsCache[0].x > atlasPointsCache[1].x
-              ? atlasPointsCache[0].x - atlasPointsCache[1].x
-              : atlasPointsCache[1].x - atlasPointsCache[0].x;
-          const yDiff =
-            atlasPointsCache[0].y > atlasPointsCache[1].y
-              ? atlasPointsCache[0].y - atlasPointsCache[1].y
-              : atlasPointsCache[1].y - atlasPointsCache[0].y;
+      //     // - - 2 - - 6- - - - 10
+      //     const xDiff =
+      //       atlasPointsCache[0].x > atlasPointsCache[1].x
+      //         ? atlasPointsCache[0].x - atlasPointsCache[1].x
+      //         : atlasPointsCache[1].x - atlasPointsCache[0].x;
+      //     const yDiff =
+      //       atlasPointsCache[0].y > atlasPointsCache[1].y
+      //         ? atlasPointsCache[0].y - atlasPointsCache[1].y
+      //         : atlasPointsCache[1].y - atlasPointsCache[0].y;
 
-          if (prevDiff > 0) {
-            if (curDiff > prevDiff) {
-              runtime.world.zoomTo(
-                // Generating a zoom from the wheel delta
-                0.95,
-                { x: xDiff / 2, y: yDiff / 2 },
-                true
-              );
-            }
-            if (curDiff < prevDiff) {
-              runtime.world.zoomTo(
-                // Generating a zoom from the wheel delta
-                1.05,
-                { x: xDiff / 2, y: yDiff / 2 },
-                true
-              );
-            }
-          }
+      //     if (prevDiff > 0) {
+      //       if (curDiff > prevDiff) {
+      //         runtime.world.zoomTo(
+      //           // Generating a zoom from the wheel delta
+      //           0.95,
+      //           { x: xDiff / 2, y: yDiff / 2 },
+      //           true
+      //         );
+      //       }
+      //       if (curDiff < prevDiff) {
+      //         runtime.world.zoomTo(
+      //           // Generating a zoom from the wheel delta
+      //           1.05,
+      //           { x: xDiff / 2, y: yDiff / 2 },
+      //           true
+      //         );
+      //       }
+      //     }
 
-          // Cache the distance for the next move event
-          prevDiff = curDiff;
-        }
-      }
+      //     // Cache the distance for the next move event
+      //     prevDiff = curDiff;
+      //   }
+      // }
 
-      function pointerUp(e: PointerEvent) {
-        // Remove this pointer from the cache and reset the target's
-        // background and border
-        removeFromEventCache(e);
-        // If the number of pointers down is less than two then reset diff tracker
-        if (eventCache.length < 2) {
-          prevDiff = -1;
-        }
-      }
+      // function pointerUp(e: PointerEvent) {
+      //   // Remove this pointer from the cache and reset the target's
+      //   // background and border
+      //   removeFromEventCache(e);
+      //   // If the number of pointers down is less than two then reset diff tracker
+      //   if (eventCache.length < 2) {
+      //     prevDiff = -1;
+      //   }
+      // }
 
       function resetState() {
         currentDistance = 0;
@@ -264,9 +264,9 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         }
       }
 
-      function setDataAttribute(_intent?: string) {
+      function setDataAttribute(value?: string, dataAttribute = 'intent') {
         if (parentElement) {
-          parentElement.dataset.intent = _intent;
+          parentElement.dataset[dataAttribute] = value;
         }
       }
 
@@ -307,6 +307,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
           // if we are ignoring a single finger touch, or it's a window-scroll, just 'return'
           if ((intent == '' && ignoreSingleFingerTouch == true) || intent == INTENT_SCROLL) {
             // have CanvasPanel do nothing... scroll the page
+            setDataAttribute('require-two-finger', 'notice');
             return;
           }
           const touch = e.touches[0];
@@ -379,6 +380,10 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
       function onWheel(e: WheelEvent & { atlas: { x: number; y: number } }) {
         const normalized = normalizeWheel(e);
         const zoomFactor = 1 + normalized.spinY / zoomWheelConstant;
+        if (requireMetaKeyForWheelZoom && e.metaKey == false) {
+          setDataAttribute('meta-required', 'notice');
+          return;
+        }
         runtime.world.zoomTo(
           // Generating a zoom from the wheel delta
           zoomFactor,

--- a/src/modules/popmotion-controller/popmotion-controller.ts
+++ b/src/modules/popmotion-controller/popmotion-controller.ts
@@ -60,7 +60,7 @@ export const defaultConfig: Required<PopmotionControllerConfig> = {
   ignoreSingleFingerTouch: true,
   enablePanOnWait: true,
   panOnWaitDelay: 40,
-  debug: true,
+  debug: false,
   onPanInSketchMode: () => {
     // no-op
   },
@@ -392,7 +392,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
       // runtime.world.addEventListener('pointermove', pointerMove);
 
       runtime.world.addEventListener('mouseup', onMouseUp);
-      runtime.world.addEventListener('touchend', onMouseUp);
+      window.addEventListener('touchend', onMouseUp);
       runtime.world.addEventListener('touchstart', onTouchStart);
       runtime.world.addEventListener('mousedown', onMouseDown);
 
@@ -402,6 +402,8 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
       window.addEventListener('mousemove', onMouseMove);
 
       if (parentElement) {
+        // if this is bound to the window, then the entire interaction model goes haywire
+        // unclear 100% why
         parentElement.addEventListener('touchmove', onTouchMove as any);
       }
 
@@ -450,7 +452,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         runtime.world.removeEventListener('touchstart', onTouchStart);
         runtime.world.removeEventListener('mousedown', onMouseDown);
 
-        runtime.world.removeEventListener('touchend', onWindowMouseUp);
+        window.removeEventListener('touchend', onWindowMouseUp);
         window.removeEventListener('mouseup', onWindowMouseUp);
 
         runtime.world.removeEventListener('mousemove', onMouseMove);

--- a/src/modules/popmotion-controller/popmotion-controller.ts
+++ b/src/modules/popmotion-controller/popmotion-controller.ts
@@ -191,7 +191,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
       function resetState() {
         currentDistance = 0;
         intent = '';
-        setDebugBorder();
+        setDataAttribute();
         touchStartTime = 0;
       }
 
@@ -264,13 +264,9 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         }
       }
 
-      function setDebugBorder(border = '1px solid transparent') {
-        if (debug == false) {
-          return;
-        }
-        const el = document.querySelector('.atlas') as HTMLElement;
-        if (el) {
-          el.style.border = border;
+      function setDataAttribute(_intent?: string) {
+        if (parentElement) {
+          parentElement.dataset.intent = _intent;
         }
       }
 
@@ -293,8 +289,8 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
             { x: e.touches[1].clientX, y: e.touches[1].clientY }
           );
           isMulti = true;
-          setDebugBorder('1px solid blue');
         }
+        setDataAttribute(intent);
 
         if (state.isPressing && e.touches.length === 1) {
           if (enablePanOnWait) {
@@ -302,13 +298,12 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
             // anything faster is a window scroll
             if (performance.now() - touchStartTime < panOnWaitDelay && intent == '') {
               intent = INTENT_SCROLL;
-              setDebugBorder('1px solid red');
             }
             if (intent == '') {
-              setDebugBorder('1px solid green');
               intent = INTENT_PAN;
             }
           }
+          setDataAttribute(intent);
           // if we are ignoring a single finger touch, or it's a window-scroll, just 'return'
           if ((intent == '' && ignoreSingleFingerTouch == true) || intent == INTENT_SCROLL) {
             // have CanvasPanel do nothing... scroll the page

--- a/src/modules/react-reconciler/Atlas.tsx
+++ b/src/modules/react-reconciler/Atlas.tsx
@@ -519,7 +519,7 @@ export const Atlas: React.FC<
         <style>{`.atlas-width-${widthClassName} { width: ${restProps.width}px; height: ${restProps.height}px; }`}</style>
       ) : (
         <style>{`
-        .atlas { position: relative; user-select: none; display: flex; background: var(--atlas-background, #000); z-index: var(--atlas-z-index, 10); touch-action: none; }
+        .atlas { position: relative; display: flex; background: var(--atlas-background, #000); z-index: var(--atlas-z-index, 10); -webkit-touch-callout: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; }
         .atlas-width-${widthClassName} { width: ${restProps.width}px; height: ${restProps.height}px; }
         .atlas-canvas { flex: 1 1 0px; }
         .atlas-canvas:focus, .atlas-static-container:focus { outline: none }

--- a/src/modules/react-reconciler/presets/default-preset.ts
+++ b/src/modules/react-reconciler/presets/default-preset.ts
@@ -50,6 +50,7 @@ export function defaultPreset({
         minZoomFactor: 0.5,
         maxZoomFactor: 3,
         enableClickToZoom: false,
+        parentElement: canvasElement,
         ...(controllerConfig || {}),
       })
     : undefined;

--- a/src/modules/react-reconciler/presets/static-preset.ts
+++ b/src/modules/react-reconciler/presets/static-preset.ts
@@ -34,6 +34,7 @@ export function staticPreset({
         minZoomFactor: 0.5,
         maxZoomFactor: 3,
         enableClickToZoom: false,
+        parentElement: containerElement,
         ...(controllerConfig || {}),
       })
     : undefined;

--- a/stories/annotations.stories.tsx
+++ b/stories/annotations.stories.tsx
@@ -266,8 +266,11 @@ export const mobileSize = () => {
     <>
       <style>{`
         .my-atlas {
-          --atlas-background: #fff; 
           --atlas-focus: 5px solid green;
+        }
+        body {
+          /* this background helps with identifying whether the window or the image is moving */
+          background: repeating-linear-gradient( 45deg, #606dbc, #606dbc 10px,#465298 10px, #465298 20px);
         }
       `}</style>
       <div className="my-atlas" style={{ height: '100vh', width: '100%', background: 'red' }}>
@@ -278,6 +281,14 @@ export const mobileSize = () => {
         </AtlasAuto>
       </div>
       <style>{`body[style]{padding: 0 !important}`}</style>
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <i>this allows testing of scrolling</i>
     </>
   );
 };

--- a/stories/annotations.stories.tsx
+++ b/stories/annotations.stories.tsx
@@ -271,6 +271,10 @@ export const mobileSize = () => {
         body {
           /* this background helps with identifying whether the window or the image is moving */
           background: repeating-linear-gradient( 45deg, #606dbc, #606dbc 10px,#465298 10px, #465298 20px);
+          [data-intent] { border: 1px solid transparent; }
+          [data-intent='pan'] { border: 1px solid red; }
+          [data-intent='gesture'] { border: 1px solid blue; }
+          [data-intent='scroll'] { border: 1px solid green; }
         }
       `}</style>
       <div className="my-atlas" style={{ height: '100vh', width: '100%', background: 'red' }}>


### PR DESCRIPTION
@stephenwf  I've found that adding a touch-model interaction on-top of the canvas-panel isn’t working. Instead, it would work better if it was built into the Atlas interaction model. I'm more than open to thoughts and ideas here too.

This helps address some of this more cleanly:
1. it addresses the fact that the browser-event-manager registers duplicate event listeners without removing them

2. it removes the `touch-action: none;` and `pointer-events: none;` which was preventing the window from listening to scroll based touches.

3. it replaces the above with making sure that `e.preventDefault()` is called when we don’t want to scroll because this does the same thing [see this](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action):

 
<ul><I>Applications using Touch events disable the browser handling of gestures by calling preventDefault(), but should also use touch-action to ensure the browser knows the intent of the application before any event listeners have been invoked</I>
</ul>
4. With this set, we can now use `e.preventDefault()` in various places to determine when we want the event to be passed to the window.

5. I also added some custom `user-select` settings to make sure that a long touch doesn’t try to select in Safari

6. I also found that binding touch-move to the window was causing issues, so I bound it to the parent element of the canvas.

New interaction modes:

1. **ignoreSingleFingerTouch** when this is enabled a single finger touch does nothing, instead of panning, it allows the window to scroll.

2. **enablePanOnWait** in this interaction model it assumes that a user will wait a brief moment between when the press and when the move when the intent is to “pan.”

**Question: can I modify the popMotionController arguments in CanvasPanel — is this a matter of defining and setting them in the `useAtlas` setup in CanvasPanel?

