### PR TITLE
addressing invalid size calculations

### DIFF
--- a/src/spacial-content/tiled-image.ts
+++ b/src/spacial-content/tiled-image.ts
@@ -119,13 +119,14 @@ export class TiledImage extends BaseObject implements SpacialContent {
     tile: { width: number; height?: number },
     scaleFactor: number,
     service?: ImageService,
-    format?: string
+    format?: string,
+    useFloorCalc?: boolean
   ): TiledImage {
     // Always set a height.
     tile.height = tile.height ? tile.height : tile.width;
     // Dimensions of full image (scaled).
-    const fullWidth = Math.round(canvas.width / scaleFactor);
-    const fullHeight = Math.round(canvas.height / scaleFactor);
+    const fullWidth = useFloorCalc ? Math.floor(canvas.width / scaleFactor) : Math.ceil(canvas.width / scaleFactor);
+    const fullHeight = useFloorCalc ? Math.floor(canvas.height / scaleFactor) : Math.ceil(canvas.height / scaleFactor);
     // number of points in the x direction.
     const mWidth = Math.ceil(fullWidth / tile.width);
     // number of points in the y direction

--- a/src/spacial-content/tiled-image.ts
+++ b/src/spacial-content/tiled-image.ts
@@ -124,8 +124,8 @@ export class TiledImage extends BaseObject implements SpacialContent {
     // Always set a height.
     tile.height = tile.height ? tile.height : tile.width;
     // Dimensions of full image (scaled).
-    const fullWidth = Math.ceil(canvas.width / scaleFactor);
-    const fullHeight = Math.ceil(canvas.height / scaleFactor);
+    const fullWidth = Math.round(canvas.width / scaleFactor);
+    const fullHeight = Math.round(canvas.height / scaleFactor);
     // number of points in the x direction.
     const mWidth = Math.ceil(fullWidth / tile.width);
     // number of points in the y direction

--- a/stories/annotations.stories.tsx
+++ b/stories/annotations.stories.tsx
@@ -34,9 +34,9 @@ const staticTiles = [
     height: 4100,
   },
   {
-    id: 'https://media.getty.edu/iiif/image/b1cfdeaa-3013-4db1-9513-1c4c250802d7',
-    width: 5012,
-    height: 3912,
+    id: 'https://media.getty.edu/iiif/image/6c3b8e93-f3c6-4782-b670-16d065d26643',
+    width: 3414,
+    height: 4097,
   },
   {
     id: 'https://iiif.bodleian.ox.ac.uk/iiif/image/5009dea1-d1ae-435d-a43d-453e3bad283f/info.json',

--- a/stories/annotations.stories.tsx
+++ b/stories/annotations.stories.tsx
@@ -29,9 +29,14 @@ const staticTiles = [
     id: 'https://gallica.bnf.fr/iiif/ark:/12148/btv1b531454753/f1',
   },
   {
-    id: 'https://iiif.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000001.jp2/info.json',
-    width: 5233,
-    height: 7200,
+    id: 'https://media.getty.edu/iiif/image/97460b7d-78ed-4d43-96a3-14c81052d82f',
+    width: 5012,
+    height: 4100,
+  },
+  {
+    id: 'https://media.getty.edu/iiif/image/b1cfdeaa-3013-4db1-9513-1c4c250802d7',
+    width: 5012,
+    height: 3912,
   },
   {
     id: 'https://iiif.bodleian.ox.ac.uk/iiif/image/5009dea1-d1ae-435d-a43d-453e3bad283f/info.json',

--- a/stories/annotations.stories.tsx
+++ b/stories/annotations.stories.tsx
@@ -29,14 +29,9 @@ const staticTiles = [
     id: 'https://gallica.bnf.fr/iiif/ark:/12148/btv1b531454753/f1',
   },
   {
-    id: 'https://media.getty.edu/iiif/image/97460b7d-78ed-4d43-96a3-14c81052d82f',
-    width: 5012,
-    height: 4100,
-  },
-  {
-    id: 'https://media.getty.edu/iiif/image/6c3b8e93-f3c6-4782-b670-16d065d26643',
-    width: 3414,
-    height: 4097,
+    id: 'https://iiif.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000001.jp2/info.json',
+    width: 5233,
+    height: 7200,
   },
   {
     id: 'https://iiif.bodleian.ox.ac.uk/iiif/image/5009dea1-d1ae-435d-a43d-453e3bad283f/info.json',


### PR DESCRIPTION
@stephenwf this feels simple and there may be a more holistic solution elsewhere but I traced this when digging into the issue I first raised in https://github.com/digirati-co-uk/iiif-canvas-panel/issues/275 where we're seeing invalid image size requests in very rare instances when using the `skip-sizes` prop in canvas panel.

From my testing it appears that when we're calculating dimensions of the canvas at the various scaleFactors in `tiled-image`, the round up via `math.ceil` can result in a subsequent points/tile calculation that slightly exceeds the dimensions that the image service can provide.

Not sure if `math.round` or `math.floor` is the better approach here or if there might be adverse effects I'm overlooking, but from what I can tell either resolves the issue with the known problematic Getty images (two of which I have here in the flexbox story) without causing rendering issues in any of the other fixtures in atlas or canvas panel.