### PR TITLE
Feature/rotate around pivot

### DIFF
--- a/src/__tests__/modules/canvas-renderer-image-stretch.test.ts
+++ b/src/__tests__/modules/canvas-renderer-image-stretch.test.ts
@@ -1,0 +1,242 @@
+/** @vitest-environment happy-dom */
+
+import { dna } from '@atlas-viewer/dna';
+import { CanvasRenderer, ImageStretchDebugEvent, isImageStretched } from '../../modules/canvas-renderer/canvas-renderer';
+
+// Detects a distinct failure mode from the rotation blur fix: a tile whose
+// *loaded* image doesn't share the target canvas's aspect ratio gets
+// drawImage()'d into it anyway (schedulePaintToCanvas always does
+// `ctx.drawImage(image, 0, 0, targetWidth, targetHeight)`, with no check
+// that the image is actually shaped to fit) -- the tile then renders
+// visibly stretched or squashed, not just blurry. This can happen when an
+// image server ignores/misreads requested crop or size parameters and
+// returns something a different shape than what was asked for.
+
+describe('isImageStretched', () => {
+  test('identical dimensions are not stretched', () => {
+    expect(isImageStretched(512, 512, 512, 512)).toBe(false);
+  });
+
+  test('same aspect ratio at a different absolute size is not stretched (just softer/sharper, uniform scaling)', () => {
+    // A server returning e.g. 1023px for a requested 1024px (common
+    // off-by-one rounding) scales uniformly -- no visible distortion.
+    expect(isImageStretched(1023, 768, 1024, 768.75)).toBe(false);
+    expect(isImageStretched(256, 256, 1024, 1024)).toBe(false);
+  });
+
+  test('a meaningfully different aspect ratio is stretched', () => {
+    // Target wants a 2:1 tile; the loaded image is square -- drawImage will
+    // squash it vertically to fit, visibly distorting it.
+    expect(isImageStretched(512, 512, 1024, 512)).toBe(true);
+  });
+
+  test('a small aspect-ratio drift within tolerance is not flagged, and just outside it is', () => {
+    // 400x300 (ratio 1.3333) vs 400x298 (ratio ~1.3423), a ~0.67% drift.
+    expect(isImageStretched(400, 300, 400, 298)).toBe(false);
+    // 400x300 vs 400x260 (ratio ~1.5385) is well outside 1%.
+    expect(isImageStretched(400, 300, 400, 260)).toBe(true);
+  });
+
+  test('missing/zero dimensions (e.g. image not yet decoded) are never flagged', () => {
+    expect(isImageStretched(0, 0, 512, 512)).toBe(false);
+    expect(isImageStretched(512, 512, 0, 0)).toBe(false);
+  });
+});
+
+// Fake `paint` shaped like the parts of SingleImage/TiledImage that
+// schedulePaintToCanvas actually touches, avoiding a real network image
+// load or a full SingleImage/TiledImage instance -- schedulePaintToCanvas
+// itself takes imageBuffer as an explicit argument rather than reading it
+// off paint.__host, so this doesn't need prepareLayer()/a real host either.
+function makeFakePaint(targetWidth: number, targetHeight: number, x = 0, y = 0) {
+  return {
+    id: 'fake-paint',
+    display: {
+      scale: 1,
+      // A single "tile" covering (x,y)-(x+targetWidth,y+targetHeight).
+      points: dna([1, x, y, x + targetWidth, y + targetHeight]),
+    },
+    getImageUrl(index: number) {
+      return `https://example.org/fake-image/${index}`;
+    },
+  } as any;
+}
+
+function createMockContext() {
+  return {
+    imageSmoothingEnabled: true,
+    save: vi.fn(),
+    restore: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    drawImage: vi.fn(),
+  } as any;
+}
+
+// A real CanvasRenderer instance (not Object.create(...prototype) with a
+// handful of manually-set fields) -- schedulePaintToCanvas's current
+// implementation depends on a lot of constructor-initialized state
+// (requiredTileKeys, imageRequestPool, imageLoadingConfig, ...) that a
+// partial mock would have to reproduce by hand, and diverge from silently
+// the next time that implementation changes.
+function createRenderer() {
+  const context = createMockContext();
+  const canvas = {
+    width: 256,
+    height: 256,
+    style: { transition: '', opacity: '1' },
+    dataset: {},
+    getBoundingClientRect: () => ({ x: 0, y: 0, top: 0, left: 0, width: 256, height: 256 }),
+    getContext: vi.fn(() => context),
+  } as any as HTMLCanvasElement;
+  return { renderer: new CanvasRenderer(canvas, { readiness: 'immediate' }), context };
+}
+
+// Drives schedulePaintToCanvas's two-stage loading queue synchronously:
+// mocks imageRequestPool.acquire (real schedulePaintToCanvas's actual
+// network path) to resolve with `fakeImage`, pops and awaits the network
+// task, then pops the decode task and runs its queued drawCalls entry --
+// mirroring canvas-image-loading.test.ts's own established pattern for
+// driving this same queue. `beforeDraw` runs after the tile has started
+// loading but before it's actually drawn -- e.g. to remove it from
+// `renderer.visible`, simulating it scrolling off screen while still in
+// flight.
+async function runSchedulePaintToCanvas(
+  fakeImage: { naturalWidth: number; naturalHeight: number },
+  paint: any,
+  beforeDraw?: (renderer: any) => void
+) {
+  const { renderer } = createRenderer();
+  renderer.visible = [paint];
+  vi.spyOn((renderer as any).imageRequestPool, 'acquire').mockReturnValue({
+    requestKey: 'req',
+    release: vi.fn(),
+    promise: Promise.resolve(fakeImage),
+  });
+
+  const imageBuffer = { canvas: undefined, canvases: [] as string[], indices: [] as number[], loaded: [] as number[], loading: false };
+
+  renderer.schedulePaintToCanvas(imageBuffer, paint, 0, 1, false);
+  expect(renderer.loadingQueue.length).toBe(1);
+  await renderer.loadingQueue.shift()!.task();
+
+  expect(renderer.loadingQueue.length).toBe(1);
+  if (beforeDraw) {
+    beforeDraw(renderer);
+  }
+  const drawTaskPromise = renderer.loadingQueue.shift()!.task();
+  expect(renderer.drawCalls.length).toBe(1);
+  renderer.drawCalls[0]();
+  await drawTaskPromise;
+}
+
+describe('CanvasRenderer#debugImageStretch hook', () => {
+  // happy-dom's canvas element doesn't implement getContext() at all (the
+  // method is missing outright, not just non-functional); the decode
+  // task's own tile canvas only calls drawImage() on it, so a plain no-op
+  // stub is enough to exercise the real code path (including the hook
+  // call, which happens just before drawImage) without needing a real
+  // canvas backend.
+  const originalGetContext = (HTMLCanvasElement.prototype as any).getContext;
+
+  beforeEach(() => {
+    (HTMLCanvasElement.prototype as any).getContext = () => ({ drawImage: () => {} });
+  });
+
+  afterEach(() => {
+    CanvasRenderer.debugImageStretch = undefined;
+    (HTMLCanvasElement.prototype as any).getContext = originalGetContext;
+  });
+
+  test('does not fire until the queued draw call actually runs', async () => {
+    const events: ImageStretchDebugEvent[] = [];
+    CanvasRenderer.debugImageStretch = (event) => events.push(event);
+
+    const { renderer } = createRenderer();
+    const paint = makeFakePaint(500, 300);
+    renderer.visible = [paint];
+    vi.spyOn((renderer as any).imageRequestPool, 'acquire').mockReturnValue({
+      requestKey: 'req',
+      release: vi.fn(),
+      promise: Promise.resolve({ naturalWidth: 500, naturalHeight: 300 }),
+    });
+    const imageBuffer = { canvas: undefined, canvases: [] as string[], indices: [] as number[], loaded: [] as number[], loading: false };
+
+    renderer.schedulePaintToCanvas(imageBuffer, paint, 0, 1, false);
+    await renderer.loadingQueue.shift()!.task();
+    // Deliberately not awaited: the decode task's promise only resolves via
+    // its own drawCalls entry, which is about to be queued but is not run
+    // here -- calling .task() still performs its synchronous setup (the
+    // drawCalls.push), which is all this test needs.
+    renderer.loadingQueue.shift()!.task();
+
+    // The draw call is queued but deliberately not invoked -- matches real
+    // rendering, where drawCalls run on the next frame, not synchronously
+    // with loading.
+    expect(renderer.drawCalls.length).toBe(1);
+    expect(events).toEqual([]);
+  });
+
+  test('reports stretched: false for an image whose aspect ratio matches its tile', async () => {
+    const events: ImageStretchDebugEvent[] = [];
+    CanvasRenderer.debugImageStretch = (event) => events.push(event);
+
+    const paint = makeFakePaint(500, 300);
+    await runSchedulePaintToCanvas({ naturalWidth: 500, naturalHeight: 300 }, paint);
+
+    expect(events.length).toBe(1);
+    expect(events[0].targetWidth).toBe(500);
+    expect(events[0].targetHeight).toBe(300);
+    expect(events[0].naturalWidth).toBe(500);
+    expect(events[0].naturalHeight).toBe(300);
+    expect(events[0].paintId).toBe('fake-paint');
+    expect(events[0].x).toBe(0);
+    expect(events[0].y).toBe(0);
+    expect(events[0].stretched).toBe(false);
+    expect(events[0].isVisible).toBe(true);
+  });
+
+  test('reports the tile\'s actual position for a tile that is not at the image origin', async () => {
+    const events: ImageStretchDebugEvent[] = [];
+    CanvasRenderer.debugImageStretch = (event) => events.push(event);
+
+    // The second tile in a grid, offset from the image's own origin -- e.g.
+    // where a debug overlay would need to draw its label.
+    const paint = makeFakePaint(500, 300, 1024, 768);
+    await runSchedulePaintToCanvas({ naturalWidth: 500, naturalHeight: 300 }, paint);
+
+    expect(events.length).toBe(1);
+    expect(events[0].x).toBe(1024);
+    expect(events[0].y).toBe(768);
+  });
+
+  test('reports stretched: true for an image server that returned the wrong shape', async () => {
+    const events: ImageStretchDebugEvent[] = [];
+    CanvasRenderer.debugImageStretch = (event) => events.push(event);
+
+    // Tile expects a 500x300 (landscape) image; the "server" returned a
+    // 300x500 (portrait) one instead -- e.g. a misread rotate/crop param.
+    const paint = makeFakePaint(500, 300);
+    await runSchedulePaintToCanvas({ naturalWidth: 300, naturalHeight: 500 }, paint);
+
+    expect(events.length).toBe(1);
+    expect(events[0].stretched).toBe(true);
+  });
+
+  test('reports isVisible: false for a tile that scrolled off screen while its image was still loading', async () => {
+    const events: ImageStretchDebugEvent[] = [];
+    CanvasRenderer.debugImageStretch = (event) => events.push(event);
+
+    const paint = makeFakePaint(500, 300);
+    // Present in `visible` when loading started (schedulePaintToCanvas's
+    // early-return check passes), removed before the image actually finished
+    // loading and got drawn -- a real race between a slow network fetch and
+    // the user panning/zooming away.
+    await runSchedulePaintToCanvas({ naturalWidth: 500, naturalHeight: 300 }, paint, (renderer) => {
+      renderer.visible = renderer.visible.filter((p: any) => p !== paint);
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].isVisible).toBe(false);
+  });
+});

--- a/src/__tests__/modules/canvas-renderer-rotation-smoothing.test.ts
+++ b/src/__tests__/modules/canvas-renderer-rotation-smoothing.test.ts
@@ -1,0 +1,129 @@
+/** @vitest-environment happy-dom */
+
+import { CanvasRenderer, needsSmoothing } from '../../modules/canvas-renderer/canvas-renderer';
+import { SingleImage } from '../../spacial-content/single-image';
+
+// Regression test for a real reported bug: rotate the canvas (even a clean
+// 90deg) while zoomed in to a tile's native resolution, and it visibly
+// blurs -- even though the tile is already being drawn 1:1 (not
+// under-resolved, the earlier "tile is blurry" bug). The cause: paint()'s
+// destination x/y/width/height (and, for rotated content, the
+// translate/rotate pivot) are raw floats from continuous pan/zoom/rotate
+// math, never snapped to integer device pixels. With imageSmoothingEnabled
+// left on unconditionally, that sub-pixel misalignment gets bilinearly
+// resampled on every draw, softening a tile that's already at full
+// resolution. needsSmoothing() (and paint()'s use of it) fixes this by only
+// asking for smoothing when the draw is actually resizing the image.
+
+describe('needsSmoothing', () => {
+  test('an exact 1:1 draw does not need smoothing', () => {
+    expect(needsSmoothing(512, 512, 512, 512)).toBe(false);
+  });
+
+  test('sub-pixel rounding slop (well under a device pixel) still counts as 1:1', () => {
+    expect(needsSmoothing(363, 1024, 363.2, 1023.6)).toBe(false);
+  });
+
+  test('a genuinely upscaled draw needs smoothing to avoid blockiness', () => {
+    expect(needsSmoothing(256, 256, 512, 512)).toBe(true);
+  });
+
+  test('a genuinely downscaled draw needs smoothing', () => {
+    expect(needsSmoothing(1024, 1024, 512, 512)).toBe(true);
+  });
+
+  test('a custom tolerance is respected', () => {
+    expect(needsSmoothing(500, 500, 504, 504, 5)).toBe(false);
+    expect(needsSmoothing(500, 500, 504, 504, 2)).toBe(true);
+  });
+});
+
+function createMockContext() {
+  return {
+    imageSmoothingEnabled: true,
+    globalAlpha: 1,
+    save: vi.fn(),
+    restore: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    drawImage: vi.fn(),
+  } as any;
+}
+
+// A real CanvasRenderer instance (not Object.create(...prototype) with a
+// handful of manually-set fields) -- paint()'s current implementation
+// reads a lot of constructor-initialized state on its way to the
+// smoothing decision (requiredTileKeys, tileState, layer-activity/fade
+// bookkeeping, ...), all wrapped in a try/catch that silently swallows any
+// error from a field a partial mock forgot -- which reads as "smoothing
+// was never touched, still whatever the mock ctx started at" rather than
+// a helpful failure. Matches canvas-image-loading.test.ts's own
+// createRenderer pattern.
+function createRenderer() {
+  const context = createMockContext();
+  const canvas = {
+    width: 1000,
+    height: 1000,
+    style: { transition: '', opacity: '1' },
+    dataset: {},
+    getBoundingClientRect: () => ({ x: 0, y: 0, top: 0, left: 0, width: 1000, height: 1000 }),
+    getContext: vi.fn(() => context),
+  } as any as HTMLCanvasElement;
+  return { renderer: new CanvasRenderer(canvas, { readiness: 'immediate' }), context };
+}
+
+// A real SingleImage instance (not a plain object) so `paint instanceof
+// SingleImage` passes -- paint()'s smoothing/drawImage branch is gated on
+// that check. Set up as already fully decoded and hosted (via
+// prepareLayer's own real host creation, then marking that single tile
+// 'decoded' with a canvas already in hostCache) so paint() takes the
+// existing-image draw path directly, without needing to also drive
+// schedulePaintToCanvas's async load pipeline just to test the smoothing
+// decision.
+function makeSingleImagePaint(renderer: CanvasRenderer, sourceWidth: number, sourceHeight: number, canvasToPaintKey: string) {
+  const paint = new SingleImage({ uri: `https://example.org/${canvasToPaintKey}.jpg`, width: sourceWidth, height: sourceHeight });
+  renderer.prepareLayer(paint, paint.points);
+  const buffer = (paint as any).__host.canvas;
+  buffer.canvases[0] = canvasToPaintKey;
+  buffer.tiles = { 0: { state: 'decoded', loadedAt: performance.now() } };
+  renderer.hostCache.set(canvasToPaintKey, { fake: 'canvas' } as any);
+  return paint;
+}
+
+describe('CanvasRenderer#paint imageSmoothingEnabled', () => {
+  test('drawing a tile at its native resolution (1:1) disables smoothing', () => {
+    const { renderer, context } = createRenderer();
+    const paint = makeSingleImagePaint(renderer, 363, 1024, 'tile-0');
+
+    // Destination width/height match the tile's own source size exactly --
+    // the same shape as an already-at-native-resolution tile drawn through
+    // a rotated world.
+    renderer.paint(paint, 0, 10, 20, 363, 1024);
+
+    expect(context.imageSmoothingEnabled).toBe(false);
+  });
+
+  test('drawing a tile that is genuinely upscaled keeps smoothing on', () => {
+    const { renderer, context } = createRenderer();
+    const paint = makeSingleImagePaint(renderer, 256, 256, 'tile-0');
+
+    // Destination is 2x the tile's own source size -- e.g. a lower
+    // pyramid-level tile stretched to fill more screen space than it has
+    // detail for, which still wants bilinear filtering to avoid a blocky look.
+    renderer.paint(paint, 0, 10, 20, 512, 512);
+
+    expect(context.imageSmoothingEnabled).toBe(true);
+  });
+
+  test('the smoothing flag is re-decided per draw, not stuck from a previous tile', () => {
+    const { renderer, context } = createRenderer();
+
+    const upscaled = makeSingleImagePaint(renderer, 256, 256, 'tile-a');
+    renderer.paint(upscaled, 0, 0, 0, 512, 512);
+    expect(context.imageSmoothingEnabled).toBe(true);
+
+    const native = makeSingleImagePaint(renderer, 363, 1024, 'tile-b');
+    renderer.paint(native, 0, 0, 0, 363, 1024);
+    expect(context.imageSmoothingEnabled).toBe(false);
+  });
+});

--- a/src/__tests__/modules/canvas-renderer-rotation.test.ts
+++ b/src/__tests__/modules/canvas-renderer-rotation.test.ts
@@ -1,0 +1,104 @@
+import { CanvasRenderer } from '../../modules/canvas-renderer/canvas-renderer';
+
+// Minimal 2D affine-matrix mock of CanvasRenderingContext2D, tracking only
+// the ops applyTransform() calls: save/translate/rotate.
+function createMatrixCtx() {
+  // [a, b, c, d, e, f] such that x' = a*x + c*y + e, y' = b*x + d*y + f
+  let m = [1, 0, 0, 1, 0, 0];
+  const multiply = (m1: number[], m2: number[]) => [
+    m1[0] * m2[0] + m1[2] * m2[1],
+    m1[1] * m2[0] + m1[3] * m2[1],
+    m1[0] * m2[2] + m1[2] * m2[3],
+    m1[1] * m2[2] + m1[3] * m2[3],
+    m1[0] * m2[4] + m1[2] * m2[5] + m1[4],
+    m1[1] * m2[4] + m1[3] * m2[5] + m1[5],
+  ];
+  return {
+    save: () => {},
+    restore: () => {},
+    translate(x: number, y: number) {
+      m = multiply(m, [1, 0, 0, 1, x, y]);
+    },
+    rotate(angle: number) {
+      m = multiply(m, [Math.cos(angle), Math.sin(angle), -Math.sin(angle), Math.cos(angle), 0, 0]);
+    },
+    apply(x: number, y: number): [number, number] {
+      return [m[0] * x + m[2] * y + m[4], m[1] * x + m[3] * y + m[5]];
+    },
+  };
+}
+
+describe('CanvasRenderer.applyTransform rotation pivot', () => {
+  test('rotates around the box own center when no cx/cy is given', () => {
+    const renderer = Object.create(CanvasRenderer.prototype) as CanvasRenderer;
+    const ctx = createMatrixCtx();
+    (renderer as any).ctx = ctx;
+
+    const owner = { rotation: 90 };
+    const paint = { __owner: { value: owner } } as any;
+
+    // Box at x=100,y=100 width=50 height=50 -> own center is (125, 125)
+    renderer.applyTransform(paint, 100, 100, 50, 50, undefined as any, undefined as any);
+
+    const [cx, cy] = ctx.apply(125, 125);
+    expect(cx).toBeCloseTo(125);
+    expect(cy).toBeCloseTo(125);
+
+    // A point 25px to the right of center should land 25px below center after a 90deg rotation.
+    const [px, py] = ctx.apply(150, 125);
+    expect(px).toBeCloseTo(125);
+    expect(py).toBeCloseTo(150);
+  });
+
+  test('rotates around a supplied pivot (cx, cy) instead of the box center', () => {
+    const renderer = Object.create(CanvasRenderer.prototype) as CanvasRenderer;
+    const ctx = createMatrixCtx();
+    (renderer as any).ctx = ctx;
+
+    const owner = { rotation: 90 };
+    const paint = { __owner: { value: owner } } as any;
+
+    // Box at x=100,y=100 width=50 height=50 (own center 125,125), but pivot is
+    // the viewport center at (400, 300) -- far from the box.
+    renderer.applyTransform(paint, 100, 100, 50, 50, 400, 300);
+
+    // The pivot itself must be a fixed point of the transform.
+    const [pivotX, pivotY] = ctx.apply(400, 300);
+    expect(pivotX).toBeCloseTo(400);
+    expect(pivotY).toBeCloseTo(300);
+
+    // The box's own center (125,125) must rotate 90deg *around the pivot* (400,300).
+    // delta = (125-400, 125-300) = (-275,-175); rotating 90deg gives (-dy, dx) = (175, -275);
+    // add the pivot back: (400+175, 300-275) = (575, 25).
+    const [cx, cy] = ctx.apply(125, 125);
+    expect(cx).toBeCloseTo(575);
+    expect(cy).toBeCloseTo(25);
+  });
+
+  // Reproduces the reported bug: with "rotate from viewport center" on and the
+  // canvas rotated 90deg, dragging the object's x slider moves it vertically
+  // on screen instead of horizontally.
+  test('at 90deg with a fixed external pivot, moving x moves the box vertically on screen', () => {
+    const renderer = Object.create(CanvasRenderer.prototype) as CanvasRenderer;
+    const owner = { rotation: 90 };
+    const paint = { __owner: { value: owner } } as any;
+    const pivot = { x: 400, y: 300 }; // fixed viewport center, independent of the box's position
+
+    const screenCenterAt = (x: number) => {
+      const ctx = createMatrixCtx();
+      (renderer as any).ctx = ctx;
+      renderer.applyTransform(paint, x, 100, 50, 50, pivot.x, pivot.y);
+      const centerX = x + 25;
+      const centerY = 100 + 25;
+      return ctx.apply(centerX, centerY);
+    };
+
+    const [beforeX, beforeY] = screenCenterAt(100);
+    const [afterX, afterY] = screenCenterAt(110); // moved 10px along the object's own (pre-rotation) x-axis
+
+    // The horizontal slider move produces almost no horizontal change on screen...
+    expect(Math.abs(afterX - beforeX)).toBeLessThan(0.01);
+    // ...and instead moves it vertically by the full 10px.
+    expect(afterY - beforeY).toBeCloseTo(10);
+  });
+});

--- a/src/__tests__/modules/overlay-renderer-text-host.test.ts
+++ b/src/__tests__/modules/overlay-renderer-text-host.test.ts
@@ -1,0 +1,112 @@
+import { OverlayRenderer } from '../../modules/overlay-renderer/overlay-renderer';
+import { Text } from '../../objects/text';
+import { Box } from '../../objects/box';
+
+// Regression test for a real crash: "TypeError: undefined is not an object
+// (evaluating 'paint.__host.tx')". paint()'s condition for "this paint has
+// (or should have) an HTML host" and createHtmlHost's condition for
+// actually *creating* that host used to be two separately written
+// booleans that had quietly drifted apart -- createHtmlHost never checked
+// options.text, so a plain <paragraph>/Text with none of
+// className/html/href never got __host set, and paint() then read .tx off
+// undefined. Both now share OverlayRenderer#shouldHostPaint, so they can't
+// diverge again.
+
+function makePlainText(): Text {
+  const text = new Text();
+  text.applyProps({
+    id: 'label',
+    text: '#8@1x',
+    target: { x: 0, y: 0, width: 90, height: 22 },
+    fontSize: 14,
+    color: '#fff',
+  });
+  return text;
+}
+
+function makePlainBox(): Box {
+  const box = new Box();
+  box.applyProps({
+    id: 'box',
+    target: { x: 0, y: 0, width: 90, height: 22 },
+  } as any);
+  return box;
+}
+
+function makeHrefBox(): Box {
+  const box = new Box();
+  box.applyProps({
+    id: 'link',
+    target: { x: 0, y: 0, width: 90, height: 22 },
+    href: 'https://example.com',
+  } as any);
+  return box;
+}
+
+describe('OverlayRenderer text/box host creation', () => {
+  test('a plain Text (no className/html/href) gets a host when options.text is on, and paint() does not throw', () => {
+    const renderer = new OverlayRenderer(document.createElement('div'), { text: true });
+    const text = makePlainText();
+
+    expect((text as any).__host).toBeUndefined();
+
+    renderer.prepareLayer(text as any);
+    expect((text as any).__host).toBeDefined();
+
+    expect(() => renderer.paint(text as any, 0, 0, 0, 90, 22)).not.toThrow();
+  });
+
+  test('a plain Text does not get a host when options.text is off, matching pre-fix opt-out behaviour', () => {
+    const renderer = new OverlayRenderer(document.createElement('div'), { text: false });
+    const text = makePlainText();
+
+    renderer.prepareLayer(text as any);
+    expect((text as any).__host).toBeUndefined();
+
+    // paint() must not attempt to read .tx off a host that was correctly
+    // never created here -- shouldHostPaint's own check for options.text
+    // short-circuits before that read.
+    expect(() => renderer.paint(text as any, 0, 0, 0, 90, 22)).not.toThrow();
+  });
+
+  test('a plain Box (no className/html) still requires options.box, unaffected by the fix', () => {
+    const renderer = new OverlayRenderer(document.createElement('div'), { box: false, text: true });
+    const box = makePlainBox();
+
+    renderer.prepareLayer(box as any);
+    expect((box as any).__host).toBeUndefined();
+    expect(() => renderer.paint(box as any, 0, 0, 0, 90, 22)).not.toThrow();
+  });
+
+  test('a Box gets a host when options.box is on, matching pre-fix behaviour', () => {
+    const renderer = new OverlayRenderer(document.createElement('div'), { box: true, text: true });
+    const box = makePlainBox();
+
+    renderer.prepareLayer(box as any);
+    expect((box as any).__host).toBeDefined();
+    expect(() => renderer.paint(box as any, 0, 0, 0, 90, 22)).not.toThrow();
+  });
+
+  // Regression test for a real, narrower regression introduced while fixing
+  // the crash above: the new shared shouldHostPaint() dropped
+  // paint.props.href from the Box branch, even though createHtmlHost (only
+  // a few lines below it) still special-cases href to build an <a> host --
+  // and HTMLPortal.tsx's box.__onCreate hook only ever fires once that host
+  // exists. A link-only box (no className/html, options.box off) used to
+  // get that host anyway; the dropped href check meant it silently stopped.
+  test('an href-only Box (no className/html/options.box) still gets an anchor host', () => {
+    const renderer = new OverlayRenderer(document.createElement('div'), { box: false, text: true });
+    const box = makeHrefBox();
+
+    renderer.prepareLayer(box as any);
+    const host = (box as any).__host;
+    expect(host).toBeDefined();
+    expect(host.element.tagName).toBe('A');
+    // .href, not getAttribute('href') -- happy-dom's HTMLAnchorElement
+    // doesn't reflect the IDL property back to the attribute, but the
+    // property is what createHtmlHost actually sets and what matters for
+    // the element to function as a link.
+    expect((host.element as HTMLAnchorElement).href).toBe('https://example.com');
+    expect(() => renderer.paint(box as any, 0, 0, 0, 90, 22)).not.toThrow();
+  });
+});

--- a/src/__tests__/modules/popmotion-controller-momentum.test.ts
+++ b/src/__tests__/modules/popmotion-controller-momentum.test.ts
@@ -74,6 +74,10 @@ function createRuntimeHarness(config: PopmotionControllerConfig = {}) {
     updateNextFrame: vi.fn(),
     constrainBounds: (nextTarget: any) => [false, nextTarget] as const,
     getHomeTarget: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+    // No-ops: this harness doesn't exercise rotateFromWorldCenter, but
+    // PopmotionController now calls these unconditionally on press/release.
+    beginInteraction: vi.fn(),
+    endInteraction: vi.fn(),
   };
 
   runtime.transitionManager = {

--- a/src/__tests__/modules/popmotion-controller-momentum.test.ts
+++ b/src/__tests__/modules/popmotion-controller-momentum.test.ts
@@ -350,6 +350,28 @@ describe('popmotion controller pan momentum', () => {
     harness.stop();
   });
 
+  test('flags runtime.panMomentumActive for the duration of an inertial pan, clearing once it settles', () => {
+    const harness = createRuntimeHarness();
+
+    now = 0;
+    dragForMomentum(harness, (value) => {
+      now = value;
+    });
+
+    // Momentum started on release -- Runtime#render's pivotSwitchPending
+    // finalize check relies on this staying true for as long as momentum is
+    // actively driving `target`, since transitionManager.hasPending() alone
+    // can't tell (see panMomentumActive's own doc comment in runtime.ts).
+    expect(harness.runtime.panMomentumActive).toBe(true);
+
+    for (let i = 0; i < 200 && harness.runtime.panMomentumActive; i++) {
+      harness.runFrame(16);
+    }
+
+    expect(harness.runtime.panMomentumActive).toBe(false);
+    harness.stop();
+  });
+
   test('can disable pan momentum', () => {
     const harness = createRuntimeHarness({ enablePanMomentum: false });
 
@@ -410,6 +432,89 @@ describe('popmotion controller pan momentum', () => {
 
     harness.runFrame(16);
     expect(harness.runtime.target[1]).toBeGreaterThan(releasedAt);
+    harness.stop();
+  });
+
+  test('a plain click mid-momentum stops the glide without moving the view', () => {
+    const harness = createRuntimeHarness();
+    now = 0;
+    dragForMomentum(harness, (value) => {
+      now = value;
+    });
+    expect(harness.runtime.panMomentumActive).toBe(true);
+
+    // Let momentum carry the view into its elastic overshoot past a bound,
+    // the same setup as the "edge hit" tests below -- this is the case a
+    // click can realistically interrupt mid-flight.
+    const boundaryX = 40;
+    harness.runtime.constrainBounds = vi.fn((nextTarget: any) => {
+      if (nextTarget[1] > boundaryX) {
+        return [true, dna([1, boundaryX, 0, boundaryX + 100, 100])] as const;
+      }
+      return [false, nextTarget] as const;
+    });
+    harness.runFrame(16);
+    const overshootPosition = dna(harness.runtime.target);
+    expect(overshootPosition[1]).toBeGreaterThan(boundaryX);
+
+    // A plain click: mousedown then mouseup with no movement in between --
+    // this should just stop the glide dead where it is, not kick off a new
+    // corrective animation of its own.
+    harness.emitWorld('mousedown', {
+      which: 1,
+      atlas: { x: overshootPosition[1], y: overshootPosition[2] },
+      preventDefault: vi.fn(),
+    });
+    harness.emitWorld('mouseup', {});
+
+    expect(harness.world.constraintBounds).not.toHaveBeenCalled();
+    expect(Array.from(harness.runtime.target)).toEqual(Array.from(overshootPosition));
+
+    harness.runFrame(16);
+    expect(Array.from(harness.runtime.target)).toEqual(Array.from(overshootPosition));
+    harness.stop();
+  });
+
+  test('a click with a pixel of real-world jitter still counts as a click, not a pan', () => {
+    // Real pointer input is never perfectly still between mousedown and
+    // mouseup -- a click routinely delivers a mousemove or two of a pixel or
+    // so of jitter. state.hasMovedSincePress flips true on any such nudge,
+    // so gating the release-time bounds correction on it alone would still
+    // let a "click" through as if it were a genuine drag. This exercises
+    // that exact case against releaseTravelPx's noise floor instead.
+    const harness = createRuntimeHarness();
+    now = 0;
+    dragForMomentum(harness, (value) => {
+      now = value;
+    });
+
+    const boundaryX = 40;
+    harness.runtime.constrainBounds = vi.fn((nextTarget: any) => {
+      if (nextTarget[1] > boundaryX) {
+        return [true, dna([1, boundaryX, 0, boundaryX + 100, 100])] as const;
+      }
+      return [false, nextTarget] as const;
+    });
+    harness.runFrame(16);
+    const overshootPosition = dna(harness.runtime.target);
+    expect(overshootPosition[1]).toBeGreaterThan(boundaryX);
+
+    harness.emitWorld('mousedown', {
+      which: 1,
+      atlas: { x: overshootPosition[1], y: overshootPosition[2] },
+      preventDefault: vi.fn(),
+    });
+    now += 30;
+    // A single pixel of jitter -- well under any real drag, but enough to
+    // set state.hasMovedSincePress. The harness's viewerToWorld is an
+    // identity mapping with getScaleFactor() === 1, so 1 world unit away
+    // from the press position is exactly 1 screen px of jitter.
+    window.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: overshootPosition[1] + 1, clientY: overshootPosition[2] })
+    );
+    harness.emitWorld('mouseup', {});
+
+    expect(harness.world.constraintBounds).not.toHaveBeenCalled();
     harness.stop();
   });
 

--- a/src/__tests__/modules/popmotion-controller-multitouch.test.ts
+++ b/src/__tests__/modules/popmotion-controller-multitouch.test.ts
@@ -1,0 +1,258 @@
+/** @vitest-environment happy-dom */
+
+// Regression coverage for Runtime#beginInteraction/#endInteraction being
+// wired into PopmotionController -- these drive the rotate-from-center
+// pivot freeze/release (see runtime-interaction-pivot.test.ts for the
+// Runtime-side mechanics). PopmotionController's own touch/gesture model
+// was substantially redesigned upstream since this wiring was first added
+// (hold-to-home, pan momentum, a dedicated releaseGesturePointer() path
+// for a multi-touch gesture stepping down in finger count) -- this file
+// checks that beginInteraction()/endInteraction() land correctly against
+// *that* current model, using the same harness shape as
+// popmotion-controller-touch.test.ts.
+
+import { dna } from '@atlas-viewer/dna';
+import {
+  type PopmotionControllerConfig,
+  popmotionController,
+} from '../../modules/popmotion-controller/popmotion-controller';
+
+type WorldListener = (event: any) => void;
+type LayoutListener = (type: string, data?: any) => void;
+
+function createTouchList(touches: Array<{ id: number; clientX: number; clientY: number }>) {
+  const list: any = touches.map((touch) => ({
+    identifier: touch.id,
+    clientX: touch.clientX,
+    clientY: touch.clientY,
+  }));
+  list.item = (index: number) => list[index] ?? null;
+  return list;
+}
+
+function createTouchEvent(touches: Array<{ id: number; clientX: number; clientY: number }>) {
+  const touchList = createTouchList(touches);
+  return {
+    touches: touchList,
+    atlasTouches: touches.map((touch) => ({ id: touch.id, x: touch.clientX, y: touch.clientY })),
+    preventDefault: vi.fn(),
+  };
+}
+
+function createParentElement() {
+  const listeners = new Map<string, Set<(event: any) => void>>();
+  return {
+    dataset: {} as Record<string, string | undefined>,
+    addEventListener(eventName: string, handler: (event: any) => void) {
+      if (!listeners.has(eventName)) {
+        listeners.set(eventName, new Set());
+      }
+      listeners.get(eventName)!.add(handler);
+    },
+    removeEventListener(eventName: string, handler: (event: any) => void) {
+      listeners.get(eventName)?.delete(handler);
+    },
+    emit(eventName: string, payload: any) {
+      for (const handler of listeners.get(eventName) || []) {
+        handler(payload);
+      }
+    },
+  };
+}
+
+function createTouchHarness(config: PopmotionControllerConfig = {}) {
+  const worldListeners = new Map<string, Set<WorldListener>>();
+  const layoutListeners = new Set<LayoutListener>();
+  const parentElement = createParentElement();
+
+  const world = {
+    activatedEvents: [] as string[],
+    addEventListener(eventName: string, handler: WorldListener) {
+      if (!worldListeners.has(eventName)) {
+        worldListeners.set(eventName, new Set());
+      }
+      worldListeners.get(eventName)!.add(handler);
+    },
+    removeEventListener(eventName: string, handler: WorldListener) {
+      worldListeners.get(eventName)?.delete(handler);
+    },
+    addLayoutSubscriber(listener: LayoutListener) {
+      layoutListeners.add(listener);
+      return () => {
+        layoutListeners.delete(listener);
+      };
+    },
+    constraintBounds: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomTo: vi.fn(),
+  };
+
+  const target = dna([1, 0, 0, 100, 100]);
+  const pendingTransition = {
+    from: dna(target),
+    to: dna(target),
+    elapsed_time: 0,
+    total_time: 0,
+    timingFunction: (t: number) => t,
+    done: true,
+    constrain: false,
+    callback: undefined as undefined | (() => void),
+  };
+
+  const runtime: any = {
+    mode: 'explore',
+    world,
+    target,
+    getRendererScreenPosition: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+    viewerToWorld: (x: number, y: number) => ({ x, y }),
+    getScaleFactor: () => 1,
+    registerHook: () => () => undefined,
+    updateNextFrame: vi.fn(),
+    constrainBounds: (nextTarget: any) => [false, nextTarget] as const,
+    isViewportAtHome: vi.fn(() => true),
+    isViewportAtHomeZoomLevel: vi.fn(() => true),
+    getHomeTarget: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+    beginInteraction: vi.fn(),
+    endInteraction: vi.fn(),
+  };
+
+  runtime.transitionManager = {
+    stopTransition: vi.fn(),
+    getPendingTransition: vi.fn(() => pendingTransition),
+    customTransition: vi.fn((applyTransition: any) => {
+      applyTransition(pendingTransition);
+    }),
+    constrainBounds: vi.fn(),
+    constrainTarget: vi.fn(),
+    zoomTo: vi.fn(),
+    goToRegion: vi.fn(),
+  };
+
+  const controller = popmotionController({
+    parentElement: parentElement as any,
+    ...config,
+  });
+  const stop = controller.start(runtime);
+
+  return {
+    runtime,
+    world,
+    parentElement,
+    stop,
+    emitWorld(eventName: string, payload: any) {
+      for (const handler of worldListeners.get(eventName) || []) {
+        handler(payload);
+      }
+    },
+  };
+}
+
+describe('PopmotionController wires Runtime#beginInteraction/#endInteraction into real gestures', () => {
+  let now = 0;
+
+  beforeEach(() => {
+    now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('a single-finger touch begins on touchstart and ends on touchend', () => {
+    const harness = createTouchHarness();
+
+    harness.emitWorld('touchstart', createTouchEvent([{ id: 1, clientX: 0, clientY: 0 }]));
+    expect(harness.runtime.beginInteraction).toHaveBeenCalledTimes(1);
+    expect(harness.runtime.endInteraction).not.toHaveBeenCalled();
+
+    harness.emitWorld('touchend', createTouchEvent([]));
+    expect(harness.runtime.endInteraction).toHaveBeenCalledTimes(1);
+
+    harness.stop();
+  });
+
+  test('a two-finger pinch begins once on touchstart, not once per finger', () => {
+    const harness = createTouchHarness();
+
+    // Real touchstart events fire once per finger landing, each carrying
+    // the full current touch set -- exactly as onTouchStart expects.
+    harness.emitWorld('touchstart', createTouchEvent([{ id: 1, clientX: 0, clientY: 0 }]));
+    harness.emitWorld(
+      'touchstart',
+      createTouchEvent([
+        { id: 1, clientX: 0, clientY: 0 },
+        { id: 2, clientX: 100, clientY: 100 },
+      ])
+    );
+
+    // Runtime#beginInteraction is itself idempotent while already
+    // interacting (see runtime-interaction-pivot.test.ts) -- verified here
+    // as "called, and the mock's own repeated-call behavior is harmless",
+    // not "called exactly once", since the controller calls it
+    // unconditionally on every touchstart and relies on that guard.
+    expect(harness.runtime.beginInteraction).toHaveBeenCalled();
+    expect(harness.runtime.endInteraction).not.toHaveBeenCalled();
+
+    harness.stop();
+  });
+
+  test('losing one finger of a two-finger gesture ends the interaction, matching releaseGesturePointer fully ending the pointer session', () => {
+    const harness = createTouchHarness();
+
+    harness.emitWorld(
+      'touchstart',
+      createTouchEvent([
+        { id: 1, clientX: 0, clientY: 0 },
+        { id: 2, clientX: 100, clientY: 100 },
+      ])
+    );
+    harness.parentElement.emit(
+      'touchmove',
+      createTouchEvent([
+        { id: 1, clientX: 25, clientY: 25 },
+        { id: 2, clientX: 75, clientY: 75 },
+      ])
+    );
+    expect(harness.runtime.endInteraction).not.toHaveBeenCalled();
+
+    // Dropping to one finger mid-pinch -- PopmotionController's own design
+    // (releaseGesturePointer) treats this as the pointer session fully
+    // ending, not a seamless downgrade to a one-finger pan; endInteraction
+    // must follow that same "fully ended" semantics, not try to keep the
+    // pivot frozen for a continuation that doesn't happen.
+    harness.emitWorld('touchend', createTouchEvent([{ id: 2, clientX: 75, clientY: 75 }]));
+
+    expect(harness.runtime.endInteraction).toHaveBeenCalledTimes(1);
+
+    harness.stop();
+  });
+
+  test('touchcancel settling a gesture through releaseGesturePointer also ends the interaction', () => {
+    const harness = createTouchHarness();
+
+    harness.emitWorld(
+      'touchstart',
+      createTouchEvent([
+        { id: 1, clientX: 0, clientY: 0 },
+        { id: 2, clientX: 100, clientY: 100 },
+      ])
+    );
+    harness.emitWorld('touchcancel', createTouchEvent([]));
+
+    expect(harness.runtime.endInteraction).toHaveBeenCalledTimes(1);
+
+    harness.stop();
+  });
+
+  test('a mouseup that never had a matching mousedown does not end an interaction that was never begun', () => {
+    const harness = createTouchHarness();
+
+    window.dispatchEvent(new Event('mouseup'));
+
+    expect(harness.runtime.beginInteraction).not.toHaveBeenCalled();
+    expect(harness.runtime.endInteraction).not.toHaveBeenCalled();
+
+    harness.stop();
+  });
+});

--- a/src/__tests__/modules/popmotion-controller-touch.test.ts
+++ b/src/__tests__/modules/popmotion-controller-touch.test.ts
@@ -111,6 +111,10 @@ function createTouchHarness(config: PopmotionControllerConfig = {}) {
     isViewportAtHome: vi.fn(() => true),
     isViewportAtHomeZoomLevel: vi.fn(() => true),
     getHomeTarget: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+    // No-ops: this harness doesn't exercise rotateFromWorldCenter, but
+    // PopmotionController now calls these unconditionally on press/release.
+    beginInteraction: vi.fn(),
+    endInteraction: vi.fn(),
   };
 
   runtime.transitionManager = {

--- a/src/__tests__/modules/runtime-interaction-pivot.test.ts
+++ b/src/__tests__/modules/runtime-interaction-pivot.test.ts
@@ -175,6 +175,60 @@ describe('Runtime interaction-gated rotation pivot', () => {
     expect((runtime as any).currentWorldPivot()).toEqual(frozen);
   });
 
+  // Regression coverage for a real, reported bug: a quick click landing
+  // while a previous gesture's pivot switch is still pending (e.g. it's
+  // deferred behind an active inertial pan-momentum glide, see
+  // Runtime#panMomentumActive) used to silently discard that pending switch
+  // in beginInteraction() -- clearing pivotSwitchPending without ever
+  // running the compensation finalizePivotSwitch() would have applied. The
+  // object was still actually being rendered around the OLD frozen pivot
+  // right up until that click; beginInteraction() then froze a *new* pivot
+  // at the live view, so the very next frame rendered it around a different
+  // pivot with no compensating position change in between -- a real,
+  // visible jump, sideways relative to whatever was panning (a pivot
+  // change, not a bounds correction).
+  test('a new gesture starting while a previous pivot switch is still pending settles that switch first, instead of dropping it', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const { runtime, state } = makeRuntime([owner]);
+    runtime.rotateFromWorldCenter = true;
+
+    // Gesture 1: a fling. Pan happens during it, same as a real drag.
+    runtime.beginInteraction();
+    state.panOffset = { x: 200, y: 100 };
+    runtime.endInteraction();
+
+    // Momentum now carries the view further *after* the gesture ended --
+    // finalizePivotSwitch is deferred behind that (panMomentumActive),
+    // exactly like being mid-drag: the pivot is still the one frozen at
+    // gesture 1's start, not live.
+    state.panOffset = { x: 260, y: 140 };
+    expect((runtime as any).pivotSwitchPending).toBe(true);
+
+    const pivotBeforeClick = renderedCenterOfPivot(runtime);
+    const rawBeforeClick = rawScreenCenter(runtime, owner);
+    const renderedBeforeClick = renderedCenter(rawBeforeClick, pivotBeforeClick, owner.rotation);
+
+    // Gesture 2: a quick click interrupts the glide (momentum's own
+    // stopPanMomentum() already halted `target`, so no further panning
+    // happens here) while gesture 1's switch is still pending.
+    runtime.beginInteraction();
+
+    const pivotAfterClick = renderedCenterOfPivot(runtime);
+    const rawAfterClick = rawScreenCenter(runtime, owner);
+    const renderedAfterClick = renderedCenter(rawAfterClick, pivotAfterClick, owner.rotation);
+
+    // The object's on-screen position must be continuous across the switch
+    // -- not jump just because a new gesture happened to start while the
+    // old one's switch was still pending.
+    expect(renderedAfterClick.x).toBeCloseTo(renderedBeforeClick.x);
+    expect(renderedAfterClick.y).toBeCloseTo(renderedBeforeClick.y);
+
+    // The new gesture's own freeze took effect (pending switch was settled,
+    // not left dangling).
+    expect((runtime as any).pivotSwitchPending).toBe(false);
+    expect(runtime.isInteracting).toBe(true);
+  });
+
   test('finalizePivotSwitch compensates rotated objects so their rendered position does not jump, then resumes live tracking', () => {
     const owner = makeOwner(100, 80, 60, 40, 30);
     const { runtime, state } = makeRuntime([owner]);

--- a/src/__tests__/modules/runtime-interaction-pivot.test.ts
+++ b/src/__tests__/modules/runtime-interaction-pivot.test.ts
@@ -1,0 +1,510 @@
+import { Runtime } from '../../renderer/runtime';
+
+type FakeOwner = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+  scale: number;
+  layers?: FakeOwner[];
+  translate(dx: number, dy: number): void;
+  applyPivotCompensationOffset(dx: number, dy: number): void;
+};
+
+function makeOwner(x: number, y: number, width: number, height: number, rotation: number, scale = 1): FakeOwner {
+  return {
+    x,
+    y,
+    width,
+    height,
+    rotation,
+    scale,
+    translate(dx: number, dy: number) {
+      this.x += dx;
+      this.y += dy;
+    },
+    applyPivotCompensationOffset(dx: number, dy: number) {
+      this.translate(dx, dy);
+    },
+  };
+}
+
+// Minimal Runtime stand-in exposing just what beginInteraction/endInteraction/
+// finalizePivotSwitch/currentWorldPivot touch. `panOffset` simulates panning:
+// it shifts the world<->viewer mapping (screen = (world - panOffset) * 2)
+// without needing a real `target` Strand, matching what happens to
+// viewerToWorld/worldToViewer while the user drags or an out-of-bounds
+// snap-back animates.
+function makeRuntime(owners: FakeOwner[]) {
+  const state = { panOffset: { x: 0, y: 0 } };
+  const runtime = Object.create(Runtime.prototype) as any;
+  runtime.viewport = { x: 0, y: 0, width: 1000, height: 800, top: 0, left: 0 };
+  runtime.viewportCenterPoint = { x: 500, y: 400 };
+  runtime._rotateFromWorldCenter = false;
+  runtime.isInteracting = false;
+  // Object.create(Runtime.prototype) skips class field initializers, so
+  // this needs setting explicitly to match the real default.
+  runtime.pivotSwitchPending = false;
+  runtime.hasSyncedRotateFromWorldCenter = true;
+  runtime.world = { getObjects: () => owners };
+  runtime.getRendererScreenPosition = () => runtime.viewport;
+  runtime.updateViewportCenterPoint = () => {
+    runtime.viewportCenterPoint = { x: runtime.viewport.width / 2, y: runtime.viewport.height / 2 };
+  };
+  runtime.getScaleFactor = () => 2;
+  runtime.worldToViewer = (x: number, y: number, width: number, height: number) => ({
+    x: (x - state.panOffset.x) * 2,
+    y: (y - state.panOffset.y) * 2,
+    width: width * 2,
+    height: height * 2,
+  });
+  runtime.viewerToWorld = (x: number, y: number) => ({ x: x / 2 + state.panOffset.x, y: y / 2 + state.panOffset.y });
+  return { runtime: runtime as Runtime, state };
+}
+
+function renderedCenter(rawCenter: { x: number; y: number }, pivot: { x: number; y: number }, angleDeg: number) {
+  const angle = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  const dx = rawCenter.x - pivot.x;
+  const dy = rawCenter.y - pivot.y;
+  return { x: pivot.x + (dx * cos - dy * sin), y: pivot.y + (dx * sin + dy * cos) };
+}
+
+function rawScreenCenter(runtime: Runtime, owner: FakeOwner) {
+  const box = (runtime as any).worldToViewer(owner.x, owner.y, owner.width, owner.height);
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+function renderedCenterOfPivot(rt: any) {
+  const world = rt.currentWorldPivot();
+  const projected = rt.worldToViewer(world.x, world.y, 0, 0);
+  return { x: projected.x, y: projected.y };
+}
+
+describe('Runtime interaction-gated rotation pivot', () => {
+  test('currentWorldPivot is undefined when rotateFromWorldCenter is off', () => {
+    const { runtime } = makeRuntime([]);
+    expect((runtime as any).currentWorldPivot()).toBeUndefined();
+  });
+
+  test('while idle, the pivot tracks the live viewport center and self-corrects across calls', () => {
+    const { runtime, state } = makeRuntime([]);
+    runtime.rotateFromWorldCenter = true;
+
+    const first = (runtime as any).currentWorldPivot();
+    expect(first).toEqual({ x: 250, y: 200 }); // viewerToWorld(500,400) with panOffset 0
+
+    // Simulate a view change between frames (e.g. settling into home
+    // position, or a programmatic pan) -- idle tracking must reflect it
+    // immediately, not hold onto the old value.
+    state.panOffset = { x: 50, y: 25 };
+    const second = (runtime as any).currentWorldPivot();
+    expect(second).toEqual({ x: 300, y: 225 });
+  });
+
+  test('beginInteraction freezes the pivot; panning during the gesture does not move it', () => {
+    const { runtime, state } = makeRuntime([]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+    const captured = (runtime as any).currentWorldPivot();
+
+    // Simulate panning while the gesture is in progress.
+    state.panOffset = { x: 200, y: 100 };
+
+    expect((runtime as any).currentWorldPivot()).toEqual(captured);
+    expect(runtime.isInteracting).toBe(true);
+  });
+
+  // Regression test for a real bug: PopmotionController#onTouchStart calls
+  // beginInteraction() on every touchstart, including a second finger
+  // touching down while the first finger's gesture is already active (a
+  // real touchstart event, since e.atlasTouches now reports 2 touches).
+  // Without a re-entry guard, that second call re-captured fixedWorldPivot
+  // at whatever the live pivot had drifted to by then -- here simulated by
+  // panning between the two beginInteraction() calls -- producing a jump
+  // exactly as a one-finger pan transitions into a two-finger pinch/rotate.
+  test('beginInteraction is a no-op when a gesture is already in progress -- panning does not sneak into a re-capture', () => {
+    const { runtime, state } = makeRuntime([]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+    const frozenAtGestureStart = (runtime as any).fixedWorldPivot;
+
+    // The drag has moved the view by the time a second finger touches down.
+    state.panOffset = { x: 200, y: 100 };
+    runtime.beginInteraction();
+
+    expect(runtime.isInteracting).toBe(true);
+    expect((runtime as any).fixedWorldPivot).toEqual(frozenAtGestureStart);
+    expect((runtime as any).currentWorldPivot()).toEqual(frozenAtGestureStart);
+  });
+
+  test('endInteraction defers the pivot switch -- the pivot stays frozen (and no object is touched) until finalizePivotSwitch runs', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const { runtime, state } = makeRuntime([owner]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+    // Baseline *after* the rotateFromWorldCenter=true assignment above,
+    // which itself compensates the switch out of own-center mode -- not
+    // the object's raw construction values.
+    const xBeforeEnd = owner.x;
+    const yBeforeEnd = owner.y;
+    state.panOffset = { x: 200, y: 100 };
+    const frozen = (runtime as any).currentWorldPivot();
+
+    runtime.endInteraction();
+
+    // The raw pointer gesture is over...
+    expect(runtime.isInteracting).toBe(false);
+    // ...but the pivot switch itself hasn't happened yet, and the object is
+    // untouched -- render() (via finalizePivotSwitch) does that, not
+    // endInteraction() directly. See finalizePivotSwitch's own comment for
+    // why it can't happen synchronously here.
+    expect((runtime as any).pivotSwitchPending).toBe(true);
+    expect((runtime as any).currentWorldPivot()).toEqual(frozen);
+    expect(owner.x).toBe(xBeforeEnd);
+    expect(owner.y).toBe(yBeforeEnd);
+
+    // Further panning while still pending continues to read through the
+    // same frozen pivot, exactly like still being mid-gesture.
+    state.panOffset = { x: 350, y: 275 };
+    expect((runtime as any).currentWorldPivot()).toEqual(frozen);
+  });
+
+  test('finalizePivotSwitch compensates rotated objects so their rendered position does not jump, then resumes live tracking', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const { runtime, state } = makeRuntime([owner]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+
+    // Pan during the gesture, same as a real drag.
+    state.panOffset = { x: 200, y: 100 };
+
+    // Snapshot immediately before finalizing: the frozen pivot has drifted
+    // from the live center by now (the whole point of freezing it), so this
+    // is genuinely a different pivot than what's used a moment later.
+    const pivotBeforeEnd = renderedCenterOfPivot(runtime);
+    const beforeRaw = rawScreenCenter(runtime, owner);
+    const beforeRendered = renderedCenter(beforeRaw, pivotBeforeEnd, owner.rotation);
+
+    runtime.endInteraction();
+    (runtime as any).finalizePivotSwitch();
+
+    // Snapshot immediately after, at the *same* (already-panned) view --
+    // only the pivot mode changed (frozen -> live), which is exactly what
+    // the compensation must cancel out.
+    const pivotAfterEnd = renderedCenterOfPivot(runtime);
+    const afterRaw = rawScreenCenter(runtime, owner);
+    const afterRendered = renderedCenter(afterRaw, pivotAfterEnd, owner.rotation);
+
+    expect(afterRendered.x).toBeCloseTo(beforeRendered.x);
+    expect(afterRendered.y).toBeCloseTo(beforeRendered.y);
+
+    expect((runtime as any).pivotSwitchPending).toBe(false);
+    // Tracking resumed live: a further pan now moves the pivot again.
+    const liveBefore = (runtime as any).currentWorldPivot();
+    state.panOffset = { x: 300, y: 300 };
+    expect((runtime as any).currentWorldPivot()).not.toEqual(liveBefore);
+  });
+
+  // Regression coverage for a real, reported bug: a rotated WorldObject
+  // nested inside another rotated WorldObject got compensated twice.
+  // syncRotationPivotPosition's tree-walk computed the absX/absY it hands
+  // to a node's children *before* that node's own
+  // applyPivotCompensationOffset call had run -- so a rotated child's own
+  // compensation math anchored itself to the parent's stale,
+  // pre-compensation position instead of the parent's actual (just-shifted)
+  // one. Confirmed live against stories/rotation.stories.tsx's
+  // CropImageBroken (rotation set on both the <world-object> and the
+  // <ImageService> it wraps, with rotateFromWorldCenter on): dragging
+  // moved the image away from the box sitting right next to it, because
+  // only the image's branch carried a second, independently-rotated
+  // wrapper node to double-compensate -- the box, with no rotation of its
+  // own, only ever inherited the outer object's single (correct) shift.
+  test('a rotated node nested inside another rotated node at the same position and angle needs no compensation of its own', () => {
+    const inner = makeOwner(0, 0, 60, 40, 87);
+    const outer = makeOwner(2000, 2000, 60, 40, 87);
+    outer.layers = [inner];
+    const { runtime, state } = makeRuntime([outer]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+    state.panOffset = { x: 200, y: 100 };
+    runtime.endInteraction();
+    (runtime as any).finalizePivotSwitch();
+
+    // outer received a real, non-trivial compensation (this scenario does
+    // exercise the mechanism -- a no-op here would make the rest of this
+    // test vacuous).
+    expect(outer.x).not.toBe(2000);
+    expect(outer.y).not.toBe(2000);
+
+    // inner sits at outer's exact position (offset 0,0) and shares its
+    // exact rotation angle, so it is -- geometrically -- the same point
+    // undergoing the same rotation as outer's own reference point: outer's
+    // shift, inherited through ordinary translation, already keeps inner's
+    // rendered position fixed with nothing left for inner's own
+    // compensation to do. Before the fix this came out non-zero (an exact
+    // duplicate of outer's own shift, once expressed in the same units).
+    expect(inner.x).toBeCloseTo(0);
+    expect(inner.y).toBeCloseTo(0);
+  });
+
+  // The general case behind the test above: a nested rotated node offset
+  // from its rotated ancestor, and rotated by a different angle, still
+  // needs its own, genuinely non-zero compensation -- the fix must not
+  // regress into "never compensate a nested rotated node," only into
+  // "compensate it correctly." Verified independently of
+  // syncRotationPivotPosition's own math: a node's rendered position
+  // (raw position rotated around whatever pivot is in effect, by its own
+  // angle) must be the same before and after the pivot switch, for *both*
+  // outer and inner, computed by literally re-deriving "rendered position"
+  // from first principles rather than re-running the code under test.
+  test('a nested rotated node offset from, and at a different angle than, its rotated ancestor still lands correctly', () => {
+    const inner = makeOwner(40, 25, 60, 40, 45);
+    const outer = makeOwner(500, 300, 60, 40, 87);
+    outer.layers = [inner];
+    const { runtime, state } = makeRuntime([outer]);
+    runtime.rotateFromWorldCenter = true;
+
+    const nestedRawScreenCenter = () => {
+      const absX = outer.x + inner.x * outer.scale;
+      const absY = outer.y + inner.y * outer.scale;
+      const box = (runtime as any).worldToViewer(absX, absY, inner.width * outer.scale, inner.height * outer.scale);
+      return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    };
+
+    runtime.beginInteraction();
+
+    // Pan during the gesture, same as a real drag -- captured *before* the
+    // "before" snapshot below (matching the established pattern in
+    // "finalizePivotSwitch compensates rotated objects..." above), so both
+    // snapshots read through the same panOffset and only the pivot mode
+    // (frozen -> live) differs between them. Capturing "before" ahead of
+    // the pan would conflate the pan's own (correct, expected) effect on
+    // rendered position with whatever the pivot switch itself changes.
+    state.panOffset = { x: 200, y: 100 };
+
+    const pivotBeforeEnd = renderedCenterOfPivot(runtime);
+    const outerBeforeRendered = renderedCenter(rawScreenCenter(runtime, outer), pivotBeforeEnd, outer.rotation);
+    const innerBeforeRendered = renderedCenter(nestedRawScreenCenter(), pivotBeforeEnd, inner.rotation);
+
+    runtime.endInteraction();
+    (runtime as any).finalizePivotSwitch();
+
+    const pivotAfterEnd = renderedCenterOfPivot(runtime);
+    const outerAfterRendered = renderedCenter(rawScreenCenter(runtime, outer), pivotAfterEnd, outer.rotation);
+    const innerAfterRendered = renderedCenter(nestedRawScreenCenter(), pivotAfterEnd, inner.rotation);
+
+    expect(outerAfterRendered.x).toBeCloseTo(outerBeforeRendered.x);
+    expect(outerAfterRendered.y).toBeCloseTo(outerBeforeRendered.y);
+    expect(innerAfterRendered.x).toBeCloseTo(innerBeforeRendered.x);
+    expect(innerAfterRendered.y).toBeCloseTo(innerBeforeRendered.y);
+
+    // Sanity: inner really did need its own, non-zero correction here --
+    // unlike the coincidental same-position/same-angle case above, this
+    // scenario doesn't let outer's shift alone cover it.
+    expect(Math.abs(inner.x - 40) + Math.abs(inner.y - 25)).toBeGreaterThan(0.01);
+  });
+
+  // Regression coverage for a real test-coverage gap: every fixture in this
+  // suite used the default scale of 1, even though
+  // Runtime#updateWorldObjectRotationPivots/#syncRotationPivotPosition
+  // accumulate parentScale * owner.scale down the tree and divide the
+  // computed compensation by that accumulated parentScale before applying
+  // it -- untested, a nested, scaled-down world-object (a thumbnail strip,
+  // or any scaled canvas) combined with rotateFromWorldCenter could land
+  // its pivot-compensation offset in the wrong local frame with nothing to
+  // catch it.
+  //
+  // Verified by an equivalence that must hold if the scale accumulation is
+  // correct: a rotated child nested under a scale=2, unrotated parent must
+  // receive exactly *half* the raw local-unit compensation that an
+  // equivalent flattened top-level object (the same child pre-multiplied
+  // by that same scale, expressed directly in world units) receives for
+  // the identical gesture -- one raw unit in the nested child's own local
+  // frame is worth two world units, thanks to its ancestor's scale, so
+  // achieving the same on-screen (world-space) correction takes half the
+  // raw delta.
+  test('a scaled ancestor divides a rotated child\'s pivot compensation by the accumulated parentScale', () => {
+    const nestedChild = makeOwner(10, 5, 60, 40, 30);
+    const parent = makeOwner(0, 0, 10, 10, 0, 2);
+    parent.layers = [nestedChild];
+
+    const flatChild = makeOwner(20, 10, 120, 80, 30);
+
+    const { runtime: nestedRuntime, state: nestedState } = makeRuntime([parent]);
+    const { runtime: flatRuntime, state: flatState } = makeRuntime([flatChild]);
+    nestedRuntime.rotateFromWorldCenter = true;
+    flatRuntime.rotateFromWorldCenter = true;
+
+    const runGesture = (runtime: any, state: any) => {
+      runtime.beginInteraction();
+      state.panOffset = { x: 200, y: 100 };
+      runtime.endInteraction();
+      runtime.finalizePivotSwitch();
+    };
+
+    const nestedXBefore = nestedChild.x;
+    const nestedYBefore = nestedChild.y;
+    const flatXBefore = flatChild.x;
+    const flatYBefore = flatChild.y;
+
+    runGesture(nestedRuntime, nestedState);
+    runGesture(flatRuntime, flatState);
+
+    const nestedDx = nestedChild.x - nestedXBefore;
+    const nestedDy = nestedChild.y - nestedYBefore;
+    const flatDx = flatChild.x - flatXBefore;
+    const flatDy = flatChild.y - flatYBefore;
+
+    // Sanity: the gesture actually moved something in both scenarios --
+    // otherwise the ratio assertions below would trivially pass at 0/0.
+    expect(Math.abs(flatDx) + Math.abs(flatDy)).toBeGreaterThan(0.01);
+
+    expect(nestedDx).toBeCloseTo(flatDx / 2);
+    expect(nestedDy).toBeCloseTo(flatDy / 2);
+  });
+
+  test('finalizePivotSwitch compensates against whatever view is current when it actually runs, not the view at endInteraction time -- the property that makes an out-of-bounds snap-back land cleanly', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const { runtime, state } = makeRuntime([owner]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+    const xBeforeEnd = owner.x;
+    state.panOffset = { x: 200, y: 100 };
+    runtime.endInteraction();
+
+    // Simulate render() stepping an out-of-bounds snap-back across several
+    // frames *after* endInteraction() returns, before the pivot switch
+    // finalizes -- render() only calls finalizePivotSwitch() once
+    // transitionManager.hasPending() has gone false again (the transition
+    // has actually settled), so by construction this always sees whichever
+    // view is current at that point, never a stale snapshot from earlier.
+    state.panOffset = { x: 40, y: 15 }; // mid-transition
+    expect(owner.x).toBe(xBeforeEnd); // still untouched -- no premature compensation
+    state.panOffset = { x: -545, y: 487 }; // transition's settled resting point
+
+    const pivotBeforeFinalize = renderedCenterOfPivot(runtime);
+    const beforeRaw = rawScreenCenter(runtime, owner);
+    const beforeRendered = renderedCenter(beforeRaw, pivotBeforeFinalize, owner.rotation);
+
+    (runtime as any).finalizePivotSwitch();
+
+    const pivotAfterFinalize = renderedCenterOfPivot(runtime);
+    const afterRaw = rawScreenCenter(runtime, owner);
+    const afterRendered = renderedCenter(afterRaw, pivotAfterFinalize, owner.rotation);
+
+    // Compensated against the settled (-545, 487) view, not the (200, 100)
+    // view captured back at endInteraction() time.
+    expect(afterRendered.x).toBeCloseTo(beforeRendered.x);
+    expect(afterRendered.y).toBeCloseTo(beforeRendered.y);
+  });
+
+  test('beginInteraction cancels a still-pending pivot switch from a previous gesture', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const { runtime, state } = makeRuntime([owner]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+    state.panOffset = { x: 200, y: 100 };
+    runtime.endInteraction();
+    expect((runtime as any).pivotSwitchPending).toBe(true);
+
+    // A new gesture starts before the previous snap-back ever settled.
+    runtime.beginInteraction();
+    expect((runtime as any).pivotSwitchPending).toBe(false);
+    expect(runtime.isInteracting).toBe(true);
+  });
+
+  test('endInteraction is a no-op when rotateFromWorldCenter is off', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const { runtime } = makeRuntime([owner]);
+    // Never turned on, never began -- matches e.g. a plain pan on a story
+    // that doesn't use rotateFromWorldCenter at all.
+    expect(() => runtime.endInteraction()).not.toThrow();
+    expect((runtime as any).pivotSwitchPending).toBe(false);
+    expect(owner.x).toBe(100);
+    expect(owner.y).toBe(80);
+  });
+
+  test('objects with no rotation are left untouched by the end-of-gesture compensation', () => {
+    const rotated = makeOwner(100, 80, 60, 40, 30);
+    const unrotated = makeOwner(200, 150, 60, 40, 0);
+    const { runtime, state } = makeRuntime([rotated, unrotated]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+    state.panOffset = { x: 150, y: 75 };
+    runtime.endInteraction();
+    (runtime as any).finalizePivotSwitch();
+
+    // Own-center rotation math has no positional effect regardless, but
+    // this also confirms the `if (!owner.rotation) continue` guard in
+    // syncRotationPivotPosition still applies through the shared helper.
+    expect(unrotated.x).toBe(200);
+    expect(unrotated.y).toBe(150);
+  });
+
+  test('turning rotateFromWorldCenter on mid-gesture captures a pivot lazily instead of returning stale/undefined', () => {
+    const { runtime } = makeRuntime([]);
+    // A gesture is already in progress (e.g. the user started dragging
+    // before rotateFromWorldCenter was ever enabled).
+    runtime.beginInteraction(); // rotateFromWorldCenter is still false here, so no capture yet
+    runtime.rotateFromWorldCenter = true;
+
+    const pivot = (runtime as any).currentWorldPivot();
+    expect(pivot).toEqual({ x: 250, y: 200 });
+
+    // And it stays frozen at that lazily-captured value for the rest of the gesture.
+    expect((runtime as any).currentWorldPivot()).toEqual(pivot);
+  });
+
+  test('turning rotateFromWorldCenter off cancels a pending pivot switch', () => {
+    const { runtime, state } = makeRuntime([]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+    state.panOffset = { x: 200, y: 100 };
+    runtime.endInteraction();
+    expect((runtime as any).pivotSwitchPending).toBe(true);
+
+    runtime.rotateFromWorldCenter = false;
+    expect((runtime as any).pivotSwitchPending).toBe(false);
+    expect((runtime as any).currentWorldPivot()).toBeUndefined();
+  });
+
+  // Regression coverage for the pivotPhase merge (isInteracting and
+  // pivotSwitchPending used to be two independent booleans; they're now
+  // accessors over one 'idle' | 'interacting' | 'switching' field -- see
+  // its own comment). This is the one write site that clears
+  // pivotSwitchPending while a gesture can still genuinely be in progress:
+  // rotateFromWorldCenter's setter clears it unconditionally when turned
+  // off, with no check on whether a gesture happens to be active. Under
+  // the old two-flag design that was naturally harmless (pivotSwitchPending
+  // and isInteracting were just separate booleans); the merged
+  // implementation has to actively choose not to fold "clear
+  // pivotSwitchPending" into "go to idle" when the phase is 'interacting'.
+  test('turning rotateFromWorldCenter off mid-gesture does not end the gesture itself', () => {
+    const { runtime } = makeRuntime([]);
+    runtime.rotateFromWorldCenter = true;
+
+    runtime.beginInteraction();
+    expect(runtime.isInteracting).toBe(true);
+
+    runtime.rotateFromWorldCenter = false;
+
+    // The raw pointer gesture is still in progress -- only the pivot mode
+    // changed. isInteracting must not have been knocked back to idle as a
+    // side effect of clearing the (already-false, since a gesture is
+    // active, not a pending switch) pivotSwitchPending flag.
+    expect(runtime.isInteracting).toBe(true);
+    expect((runtime as any).pivotSwitchPending).toBe(false);
+  });
+});

--- a/src/__tests__/modules/runtime-rotation-pivot.test.ts
+++ b/src/__tests__/modules/runtime-rotation-pivot.test.ts
@@ -1,0 +1,178 @@
+import { Runtime } from '../../renderer/runtime';
+
+type FakeOwner = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+  translate(dx: number, dy: number): void;
+  applyPivotCompensationOffset(dx: number, dy: number): void;
+};
+
+function makeOwner(x: number, y: number, width: number, height: number, rotation: number): FakeOwner {
+  return {
+    x,
+    y,
+    width,
+    height,
+    rotation,
+    translate(dx: number, dy: number) {
+      this.x += dx;
+      this.y += dy;
+    },
+    applyPivotCompensationOffset(dx: number, dy: number) {
+      this.translate(dx, dy);
+    },
+  };
+}
+
+// Minimal Runtime stand-in exposing just what compensateRotationPivotChange() touches,
+// with a world<->viewer mapping of "screen = world * 2" (scaleFactor 2, no pan offset).
+function makeRuntime(owner: FakeOwner): Runtime {
+  const runtime = Object.create(Runtime.prototype) as any;
+  runtime.viewport = { x: 0, y: 0, width: 1000, height: 800, top: 0, left: 0 };
+  runtime.viewportCenterPoint = { x: 500, y: 400 };
+  runtime._rotateFromWorldCenter = false;
+  // Simulates a runtime that has already synced this prop once (matching a
+  // real component past its first mount), so these tests exercise genuine
+  // subsequent toggles -- not the special-cased first-ever sync, which
+  // intentionally skips compensation (see the setter in runtime.ts).
+  runtime.hasSyncedRotateFromWorldCenter = true;
+  runtime.world = { getObjects: () => [owner] };
+  runtime.getRendererScreenPosition = () => runtime.viewport;
+  runtime.updateViewportCenterPoint = () => {
+    runtime.viewportCenterPoint = { x: runtime.viewport.width / 2, y: runtime.viewport.height / 2 };
+  };
+  runtime.getScaleFactor = () => 2;
+  runtime.worldToViewer = (x: number, y: number, width: number, height: number) => ({
+    x: x * 2,
+    y: y * 2,
+    width: width * 2,
+    height: height * 2,
+  });
+  runtime.viewerToWorld = (x: number, y: number) => ({ x: x / 2, y: y / 2 });
+  return runtime as Runtime;
+}
+
+// Mirrors CanvasRenderer.applyTransform's rotation math: rotate the box's raw
+// (unrotated) screen center around `pivot` by `angleDeg`.
+function renderedCenter(rawCenter: { x: number; y: number }, pivot: { x: number; y: number }, angleDeg: number) {
+  const angle = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  const dx = rawCenter.x - pivot.x;
+  const dy = rawCenter.y - pivot.y;
+  return { x: pivot.x + (dx * cos - dy * sin), y: pivot.y + (dx * sin + dy * cos) };
+}
+
+function rawScreenCenter(runtime: Runtime, owner: FakeOwner) {
+  const box = runtime.worldToViewer(owner.x, owner.y, owner.width, owner.height);
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+describe('Runtime rotation pivot compensation', () => {
+  test('toggling to viewport-center pivot renders the box in the same place', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const runtime = makeRuntime(owner);
+
+    // Before: rotateFromWorldCenter is false, so the box rotates around its own center.
+    const beforeRaw = rawScreenCenter(runtime, owner);
+    const beforeRendered = renderedCenter(beforeRaw, beforeRaw, owner.rotation);
+
+    runtime.rotateFromWorldCenter = true;
+
+    // After: it now rotates around the viewport center, but should land in the same spot.
+    const afterRaw = rawScreenCenter(runtime, owner);
+    const afterRendered = renderedCenter(afterRaw, (runtime as any).viewportCenterPoint, owner.rotation);
+
+    expect(afterRendered.x).toBeCloseTo(beforeRendered.x);
+    expect(afterRendered.y).toBeCloseTo(beforeRendered.y);
+    // And it actually had to move to achieve that (sanity check the compensation did something).
+    expect(owner.x).not.toBeCloseTo(100);
+  });
+
+  test('round trip (on then off) returns the object to its original position', () => {
+    const owner = makeOwner(100, 80, 60, 40, 45);
+    const runtime = makeRuntime(owner);
+
+    runtime.rotateFromWorldCenter = true;
+    runtime.rotateFromWorldCenter = false;
+
+    expect(owner.x).toBeCloseTo(100);
+    expect(owner.y).toBeCloseTo(80);
+  });
+
+  test('does nothing when the object has no rotation', () => {
+    const owner = makeOwner(100, 80, 60, 40, 0);
+    const runtime = makeRuntime(owner);
+
+    runtime.rotateFromWorldCenter = true;
+
+    expect(owner.x).toBe(100);
+    expect(owner.y).toBe(80);
+  });
+
+  test('setting the same value is a no-op', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const runtime = makeRuntime(owner);
+
+    runtime.rotateFromWorldCenter = false; // already false
+
+    expect(owner.x).toBe(100);
+    expect(owner.y).toBe(80);
+  });
+
+  // AtlasAuto syncs rotateFromWorldCenter via a useEffect that always fires
+  // on mount (Atlas.tsx), so a component that starts with
+  // rotateFromWorldCenter={true} still calls this setter once with a
+  // false->true transition, purely because Runtime's own field defaults to
+  // false -- not because the user toggled anything. There's no
+  // previously-rendered own-center appearance to preserve in that case, so
+  // compensating would corrupt the initial position instead of protecting
+  // it (this was the root cause of a real reported bug: an object whose
+  // rotateFromWorldCenter starts true failed to render at all, because the
+  // spurious compensation pushed it far enough that the visibility check
+  // no longer overlapped its own bounds).
+  test('does not compensate on the very first sync (component mounting with rotateFromWorldCenter already true)', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const runtime = makeRuntime(owner);
+    // Override the "already synced" simulation from makeRuntime -- this
+    // test specifically wants the fresh-mount (never synced) state.
+    (runtime as any).hasSyncedRotateFromWorldCenter = false;
+
+    runtime.rotateFromWorldCenter = true;
+
+    expect(owner.x).toBe(100);
+    expect(owner.y).toBe(80);
+
+    // A genuine later toggle (off, matching a real user action) should
+    // still compensate normally.
+    runtime.rotateFromWorldCenter = false;
+    expect(owner.x).not.toBeCloseTo(100);
+  });
+
+  // A story that starts with rotateFromWorldCenter={false} matches this
+  // class's own default, so AtlasAuto's initial sync effect calls this
+  // setter with a value equal to the current one -- the early-return branch
+  // above. That must still count as "synced": otherwise the user's first
+  // *real* toggle (false->true) would be misidentified as the special-cased
+  // initial sync and incorrectly skip compensation, producing a real,
+  // uncompensated jump on the very first click.
+  test('a no-op initial sync still counts as synced, so the first real toggle after it compensates', () => {
+    const owner = makeOwner(100, 80, 60, 40, 30);
+    const runtime = makeRuntime(owner);
+    (runtime as any).hasSyncedRotateFromWorldCenter = false;
+
+    // Simulates AtlasAuto's mount-time effect syncing the starting prop
+    // value (false), which matches Runtime's own default -- a no-op.
+    runtime.rotateFromWorldCenter = false;
+    expect((runtime as any).hasSyncedRotateFromWorldCenter).toBe(true);
+    expect(owner.x).toBe(100);
+
+    // The user's first real toggle should compensate normally, not be
+    // skipped as if it were the initial sync.
+    runtime.rotateFromWorldCenter = true;
+    expect(owner.x).not.toBeCloseTo(100);
+  });
+});

--- a/src/__tests__/modules/transition-manager.test.ts
+++ b/src/__tests__/modules/transition-manager.test.ts
@@ -85,4 +85,78 @@ describe('Transition manager', () => {
     expect(tm.getPendingTransition().to[1]).toBe(-25);
     expect(tm.getPendingTransition().to[2]).toBe(-25);
   });
+
+  // Regression test for the td-overshoot fix: a single-frame delta large
+  // enough to jump past total_time (a backgrounded tab resuming, a dropped
+  // frame, a GC pause) used to leave td > 1. easeOutQuart-shaped curves
+  // (1 - (1-t)^4) are only monotonic on [0, 1] -- fed a t past 1, they
+  // curve back down instead of continuing toward the endpoint, so `step`
+  // would land short of (or even behind) `to` on the exact frame that also
+  // marks the transition done, stranding `target` there permanently since
+  // nothing else re-triggers a correction.
+  test('runTransition clamps an overshooting delta to the transition\'s end value, not wherever a non-monotonic easing curve lands past t=1', () => {
+    const buffer = dna([1, 0, 0, 0, 0]);
+    const tm = new TransitionManager({ target: buffer } as any);
+
+    // Shaped like easeOutQuart: strictly increasing on [0,1], reaching 1 at
+    // t=1, then curving back down for t>1 -- exactly the failure mode an
+    // unclamped td would hit.
+    const nonMonotonicPastOne = (t: number) => 1 - Math.pow(1 - t, 4);
+
+    tm.customTransition((transition) => {
+      transition.to = dna([1, 100, 100, 100, 100]);
+      transition.from = dna([1, 0, 0, 0, 0]);
+      transition.total_time = 100;
+      transition.elapsed_time = 90;
+      transition.timingFunction = nonMonotonicPastOne;
+      transition.done = false;
+    });
+
+    // A single oversized delta pushes elapsed_time well past total_time in
+    // one step (90 + 40 = 130, i.e. td = 1.3 unclamped).
+    tm.runTransition(buffer, 40);
+
+    expect(buffer[1]).toBe(100);
+    expect(buffer[2]).toBe(100);
+    expect(buffer[3]).toBe(100);
+    expect(buffer[4]).toBe(100);
+    expect(tm.hasPending()).toBe(false);
+  });
+});
+
+describe('Transition manager constrainBounds', () => {
+  test('clears isConstraining when nothing needed correcting', () => {
+    const target = dna([1, 0, 0, 100, 100]);
+    const runtime = {
+      target,
+      // Reports nothing out of bounds -- the branch that matters here.
+      constrainBounds: () => [false, dna(target)],
+    };
+    const tm = new TransitionManager(runtime as any);
+
+    (tm as any).constrainBounds();
+
+    // Without the fix, this stays true forever: the only other place it's
+    // cleared is inside the corrective transition's own callback, which
+    // never runs when there was nothing to correct.
+    expect(tm.isConstraining).toBe(false);
+  });
+
+  test('leaves isConstraining true while a real correction is in flight', () => {
+    const target = dna([1, -500, -500, -400, -400]);
+    const runtime = {
+      target,
+      updateNextFrame: () => {},
+      constrainBounds: () => [true, dna([1, 0, 0, 100, 100])],
+    };
+    const tm = new TransitionManager(runtime as any);
+
+    (tm as any).constrainBounds();
+
+    // The corrective transition is now pending -- isConstraining should
+    // stay true until *that* transition's own completion callback clears
+    // it, not flip false immediately the way the "nothing to do" path does.
+    expect(tm.isConstraining).toBe(true);
+    expect(tm.hasPending()).toBe(true);
+  });
 });

--- a/src/__tests__/modules/world-far-rotated-object-selection.test.ts
+++ b/src/__tests__/modules/world-far-rotated-object-selection.test.ts
@@ -1,0 +1,101 @@
+import { dna } from '@atlas-viewer/dna';
+import { World } from '../../world';
+import { WorldObject } from '../../world-objects/world-object';
+
+// Regression fixture for a real, visually-reported bug, one level above
+// world-object-nested-rotation-selection.test.ts: World#getObjectsAt (and
+// getScheduledUpdates) filter *top-level* objects with a single
+// hidePointsOutsideRegion(this.points, target) call against each object's
+// raw, unrotated world bounds -- World has no rotation of its own, and
+// nothing above it can widen on a rotated object's behalf the way
+// WorldObject#selectionRotation lets an unrotated *ancestor* do one level
+// down. Repro: stories/sequence-panel.stories.tsx's "setup test2" button
+// (rotate from world center, zoom in, then drag/pan twice) -- confirmed
+// live via paint instrumentation that once dragging pushed the raw
+// (unrotated) viewport target past a whole top-level canvas's raw world
+// bounds, that canvas stopped being painted *at all* (not even a coarse
+// fallback layer) -- worse than the per-tile blur the WorldObject-level fix
+// targets, since nothing above World was able to recover it.
+//
+// Fixed by World#forceIncludeRotatedObjects: rather than trying to compute
+// a correctly-widened target up here (an earlier version of this fix tried
+// exactly that, reusing WorldObject#applyRotation -- see its own comment
+// for why that's geometrically incapable of the one thing it needed to do
+// whenever the shared pivot happens to equal the current target's own
+// center, which while idle it always does), any top-level object carrying
+// rotation anywhere in its own subtree is left in hidePointsOutsideRegion's
+// candidate list regardless of whether its raw bounds happen to overlap
+// target -- deferring the real, precise decision to that object's own
+// (already correct) getAllPointsAt/getObjectsAt.
+
+function makeRotatedTopLevelObject(id: string, x: number, width: number) {
+  const object = WorldObject.createWithProps({ id, x, y: 0, width, height: 400, rotation: 90 });
+  // No Runtime driving updateWorldObjectRotationPivots in this isolated
+  // test, so set a pivot directly -- same pattern already used in
+  // world-object-culling.test.ts. Placed near the *other* object (x=0) so
+  // it's plausible as a shared, world-center-ish pivot, not this object's
+  // own center.
+  (object as any).rotationPivot = { x: 200, y: 200 };
+  return object;
+}
+
+describe('World#getObjectsAt / getScheduledUpdates keep a rotated top-level object candidate even when its raw bounds miss target', () => {
+  test('getObjectsAt still returns a rotated object whose raw world bounds no longer overlap target', () => {
+    const world = new World();
+    const near = WorldObject.createWithProps({ id: 'near', x: 0, y: 0, width: 400, height: 400, rotation: 0 });
+    const far = makeRotatedTopLevelObject('far', 2451, 2411);
+    world.appendChild(near);
+    world.appendChild(far);
+
+    // Overlaps `near`'s raw bounds ([0,400]) but not `far`'s ([2451,4862])
+    // at all -- the exact shape of the real repro's target after two drags.
+    const target = dna([1, 100, 100, 300, 300]);
+
+    const result = world.getObjectsAt(target, true);
+    const ids = result.map(([owner]) => owner.id);
+
+    expect(ids).toContain('near');
+    expect(ids).toContain('far');
+  });
+
+  test('getScheduledUpdates still schedules a rotated object whose raw world bounds no longer overlap target', () => {
+    const world = new World();
+    const far = makeRotatedTopLevelObject('far', 2451, 2411);
+    let scheduled = false;
+    (far as any).getScheduledUpdates = () => {
+      scheduled = true;
+      return [];
+    };
+    world.appendChild(far);
+
+    const target = dna([1, 100, 100, 300, 300]);
+    world.getScheduledUpdates(target, 1);
+
+    expect(scheduled).toBe(true);
+  });
+
+  test('an unrotated object with no rotation anywhere in its subtree is still excluded when genuinely off-screen', () => {
+    const world = new World();
+    const near = WorldObject.createWithProps({ id: 'near', x: 0, y: 0, width: 400, height: 400, rotation: 0 });
+    const farUnrotated = WorldObject.createWithProps({
+      id: 'far-unrotated',
+      x: 2451,
+      y: 0,
+      width: 2411,
+      height: 400,
+      rotation: 0,
+    });
+    world.appendChild(near);
+    world.appendChild(farUnrotated);
+
+    const target = dna([1, 100, 100, 300, 300]);
+    const result = world.getObjectsAt(target, true);
+    const ids = result.map(([owner]) => owner.id);
+
+    // The fix only affects objects that carry rotation somewhere in their
+    // own subtree -- the fast, rotation-unaware path stays exactly as
+    // correctness-preserving as it always was for everything else.
+    expect(ids).toContain('near');
+    expect(ids).not.toContain('far-unrotated');
+  });
+});

--- a/src/__tests__/modules/world-object-culling.test.ts
+++ b/src/__tests__/modules/world-object-culling.test.ts
@@ -1,0 +1,107 @@
+import { dna, hidePointsOutsideRegion, Strand } from '@atlas-viewer/dna';
+import { WorldObject } from '../../world-objects/world-object';
+
+// Minimal target-aware leaf, mirroring TiledImage#getAllPointsAt (the real
+// content type in the reported bug): it actually consults `target` via
+// hidePointsOutsideRegion, unlike Box/SingleImage which always return
+// themselves regardless of target. strand[0] === 0 means "culled".
+function makeFakeLeaf(points: Strand) {
+  return {
+    points,
+    getAllPointsAt(target: Strand, aggregate?: Strand) {
+      const result = hidePointsOutsideRegion(points, target);
+      return [[this, result, aggregate]];
+    },
+  } as any;
+}
+
+describe('WorldObject#getAllPointsAt culling is unaffected by rotation', () => {
+  // Regression test for a real reported bug: at a particular zoom/position
+  // combination, an ImageService/TileSet's rotated wrapper -- with
+  // rotationPivot set far outside its own bounds, as happens under
+  // rotateFromWorldCenter -- was incorrectly culled, making the image
+  // invisible. Root cause: culling used to rotate the *target* around
+  // rotationPivot before intersecting it with `this.points`, which could
+  // shift a small target far outside the node's own bounds even though the
+  // node is genuinely on screen after the real (post-hoc, render-time-only)
+  // rotation is applied. See getAllPointsAt's own comment for the full
+  // architecture explanation.
+  test('a rotated object with an external pivot far outside its own bounds still exposes its content', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 0, y: 0, width: 200, height: 100, rotation: 87 });
+    // A rotationPivot far outside the object's own [0,200]x[0,100] bounds --
+    // e.g. the viewport center under rotateFromWorldCenter, at a zoom level
+    // where the object is comparatively small and far from that center.
+    owner.rotationPivot = { x: 5000, y: 3000 };
+
+    const leaf = makeFakeLeaf(dna([1, 0, 0, 200, 100]));
+    (owner as any).layers = [leaf];
+
+    // A target that exactly matches the object's own (un-rotated) bounds --
+    // the "zero headroom" case from the real bug, where the object is
+    // exactly at the edge of the visible window before any rotation is
+    // considered.
+    const target = dna([1, 0, 0, 200, 100]);
+    const aggregate = dna([1, 0, 0, 0, 0, 1, 0, 0, 1]);
+
+    const result = owner.getAllPointsAt(target, aggregate, 1);
+
+    expect(result.length).toBe(1);
+    const [, points] = result[0];
+    // points[0] === 0 means culled/invisible -- must not happen here.
+    expect(points[0]).not.toBe(0);
+  });
+
+  test('a target that genuinely does not overlap the object is still culled', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 0, y: 0, width: 200, height: 100, rotation: 87 });
+    owner.rotationPivot = { x: 5000, y: 3000 };
+
+    const leaf = makeFakeLeaf(dna([1, 0, 0, 200, 100]));
+    (owner as any).layers = [leaf];
+
+    // Far away from the object entirely -- genuinely off-screen, not just a
+    // rotation-pivot artifact.
+    const target = dna([1, 10000, 10000, 10100, 10100]);
+    const aggregate = dna([1, 0, 0, 0, 0, 1, 0, 0, 1]);
+
+    const result = owner.getAllPointsAt(target, aggregate, 1);
+
+    // Nothing selected. This used to assert the layer came back present but
+    // culled (one entry, strand[0] === 0) -- an equivalent statement of the
+    // same invariant, from when getAllPointsAt descended into its layers
+    // with the empty intersection instead of stopping at it. It no longer
+    // descends: an empty region does not survive being transformed into a
+    // child's coordinate space and re-intersected there, and would come
+    // back as a real selection several levels down -- see getAllPointsAt's
+    // own comment and world-object-empty-selection-propagation.test.ts.
+    // What this test exists to guarantee is unchanged and, if anything,
+    // now stated more directly: a genuinely far-away target paints nothing.
+    expect(result.length).toBe(0);
+  });
+
+  test('own-center rotation (no rotationPivot) also does not narrow culling based on rotation', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 0, y: 0, width: 200, height: 100, rotation: 45 });
+    // rotationPivot left undefined -- own-center mode.
+
+    const leaf = makeFakeLeaf(dna([1, 0, 0, 200, 100]));
+    (owner as any).layers = [leaf];
+
+    const target = dna([1, 0, 0, 200, 100]);
+    const aggregate = dna([1, 0, 0, 0, 0, 1, 0, 0, 1]);
+
+    const result = owner.getAllPointsAt(target, aggregate, 1);
+
+    // getAllPointsAt selects against the union of target and its
+    // rotation-aware counterpart in a single pass (see
+    // world-object-rotated-tile-selection.test.ts -- fixes a real blur bug:
+    // two independently-ordered selection/paint passes gave no guarantee a
+    // second pass's coarse fallback tile wouldn't paint over, and so
+    // visibly overwrite, a first pass's already-fine tile at the same
+    // screen position). Here target already equals this.points exactly, so
+    // the union is just target itself, and the leaf is selected once. The
+    // guarantee this test exists for -- rotation never narrows culling --
+    // still holds: it must not be culled.
+    expect(result.length).toBe(1);
+    const [, points] = result[0];
+    expect(points[0]).not.toBe(0);
+  });
+});

--- a/src/__tests__/modules/world-object-empty-selection-propagation.test.ts
+++ b/src/__tests__/modules/world-object-empty-selection-propagation.test.ts
@@ -1,0 +1,280 @@
+import { dna, hidePointsOutsideRegion, Strand } from '@atlas-viewer/dna';
+import { World } from '../../world';
+import { WorldObject } from '../../world-objects/world-object';
+
+// Regression fixture for the second half of the bug
+// world-far-rotated-object-selection.test.ts fixes -- the half that fix
+// exposed. World#forceIncludeRotatedObjects keeps a rotated top-level
+// object in the candidate list even when its raw bounds miss target, so
+// that the object's own getAllPointsAt can make the real decision. It then
+// made the wrong one, twice over:
+//
+//   1. it intersected target against `this.points`, which for a
+//      pivot-compensated subtree no longer says where the content is (see
+//      WorldObject#selectionBounds) -- so a canvas that was genuinely,
+//      visibly on screen got an *empty* intersection at the very first
+//      level; and
+//   2. that empty strand didn't stay empty: it gets translated into each
+//      child's coordinate space on the way down, rotating an empty region
+//      around a distant pivot *moves* it, and the union of where it was and
+//      where it moved to is a real rectangle again -- so two levels down,
+//      a region nobody computed on purpose got clipped against the rotated
+//      wrapper's bounds and selected a couple of tiles.
+//
+// Which is exactly the reported symptom: the canvas painted, but from the
+// wrong two tiles out of its grid, so it showed as a smeared low-resolution
+// band rather than as missing content.
+//
+// Every number below is measured, not invented -- captured from
+// stories/sequence-panel.stories.tsx's "setup test2" (rotate from world
+// center, zoom in, drag twice) by instrumenting getAllPointsAt and
+// CanvasRenderer#paint in the browser at the moment the second canvas was
+// painting blurry: two 2411x3372 canvases 40 units apart, the whole tree
+// pivot-compensated by -601 on both axes, viewport 1248x512 onto world
+// target [1217,1430 -> 2442,1942], rotated 90 degrees about the viewport
+// centre. The far canvas's top-level object still claimed x 2451..4862
+// while its tiles were painting from x 1850.
+
+const ROTATION = 90;
+const CANVAS_WIDTH = 2411;
+const CANVAS_HEIGHT = 3372;
+// Runtime#syncRotationPivotPosition applies this to the rotated node only
+// -- the nested wrapper -- leaving every ancestor's bounds behind.
+const COMPENSATION = -601;
+const COLS = 3;
+const ROWS = 4;
+
+const TARGET = dna([1, 1217, 1430, 2442, 1942]);
+// The live viewport centre, which is what the pivot tracks while idle.
+const PIVOT = { x: (TARGET[1] + TARGET[3]) / 2, y: (TARGET[2] + TARGET[4]) / 2 };
+
+const AGGREGATE = dna([1, 0, 0, 0, 0, 1, 0, 0, 1]);
+
+function makeGridLeaf(label: string, width: number, height: number) {
+  const points = dna(COLS * ROWS * 5);
+  const tileWidth = width / COLS;
+  const tileHeight = height / ROWS;
+  for (let row = 0; row < ROWS; row++) {
+    for (let col = 0; col < COLS; col++) {
+      const i = (row * COLS + col) * 5;
+      points[i] = 1;
+      points[i + 1] = col * tileWidth;
+      points[i + 2] = row * tileHeight;
+      points[i + 3] = (col + 1) * tileWidth;
+      points[i + 4] = (row + 1) * tileHeight;
+    }
+  }
+  return {
+    label,
+    points,
+    // Mirrors TiledImage#getAllPointsAt exactly.
+    getAllPointsAt(target: Strand, aggregate?: Strand) {
+      return [[this, hidePointsOutsideRegion(points, target), aggregate]];
+    },
+  } as any;
+}
+
+/**
+ * The tree shape a IIIF canvas actually renders as, as captured from the
+ * story: a plain top-level <world-object>, a plain wrapper inside it, then
+ * ImageService's own nested wrapper -- the only rotated node, and so the
+ * only one Runtime pivot-compensates -- holding the tile grid.
+ */
+function makeCanvas(id: string, worldX: number) {
+  const leaf = makeGridLeaf(`${id}-tiles`, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+  const rotated = WorldObject.createWithProps({
+    id: `${id}-rotated`,
+    x: COMPENSATION,
+    y: COMPENSATION,
+    width: CANVAS_WIDTH,
+    height: CANVAS_HEIGHT,
+    rotation: ROTATION,
+  });
+  (rotated as any).layers = [leaf];
+
+  const inner = WorldObject.createWithProps({ id: `${id}-inner`, x: 0, y: 0, width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+  (inner as any).layers = [rotated];
+
+  const outer = WorldObject.createWithProps({ id, x: worldX, y: 0, width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+  (outer as any).layers = [inner];
+
+  // Runtime#updateWorldObjectRotationPivots writes the shared world pivot
+  // onto every node, expressed in that node's own local frame.
+  outer.rotationPivot = { x: PIVOT.x, y: PIVOT.y };
+  inner.rotationPivot = { x: PIVOT.x - worldX, y: PIVOT.y };
+  rotated.rotationPivot = { x: PIVOT.x - worldX, y: PIVOT.y };
+
+  // Where this canvas's tiles are really painted, in world coordinates:
+  // the compensation offset is not reflected in `outer.points`.
+  const contentX = worldX + COMPENSATION;
+  const contentY = COMPENSATION;
+
+  return { outer, inner, rotated, leaf, contentX, contentY };
+}
+
+/**
+ * The world region genuinely on screen once the post-hoc render rotation is
+ * applied: the viewport rotated back around the pivot. Computed here from
+ * first principles for the one angle this fixture uses -- a 90 degree turn
+ * about a point keeps the centre and swaps width for height -- rather than
+ * by calling applyRotation, so this is an independent check rather than the
+ * code agreeing with itself.
+ */
+function visibleWorldRegion() {
+  const halfWidth = (TARGET[3] - TARGET[1]) / 2;
+  const halfHeight = (TARGET[4] - TARGET[2]) / 2;
+  return {
+    x1: PIVOT.x - halfHeight,
+    y1: PIVOT.y - halfWidth,
+    x2: PIVOT.x + halfHeight,
+    y2: PIVOT.y + halfWidth,
+  };
+}
+
+/** Indices of the grid tiles overlapping `region`, in leaf-local coordinates. */
+function tilesOverlapping(leaf: any, x1: number, y1: number, x2: number, y2: number) {
+  const overlapping: number[] = [];
+  for (let i = 0; i < leaf.points.length; i += 5) {
+    if (leaf.points[i + 1] < x2 && leaf.points[i + 3] > x1 && leaf.points[i + 2] < y2 && leaf.points[i + 4] > y1) {
+      overlapping.push(i / 5);
+    }
+  }
+  return overlapping;
+}
+
+/** Indices of the grid tiles a selection pass actually kept. */
+function selectedTiles(result: any[], label: string) {
+  const selected: number[] = [];
+  for (const [leaf, points] of result) {
+    if (leaf.label !== label) continue;
+    for (let i = 0; i < points.length; i += 5) {
+      if (points[i] !== 0) selected.push(i / 5);
+    }
+  }
+  return selected;
+}
+
+describe('selection survives a pivot-compensated subtree, and an empty selection stays empty', () => {
+  test('both rotated canvases select every tile that is physically on screen', () => {
+    const world = new World();
+    const near = makeCanvas('near', 0);
+    // 2451 = the second canvas's world x. Its raw bounds (2451..4862) miss
+    // the target entirely; its content (1850..4261) does not.
+    const far = makeCanvas('far', 2451);
+    world.appendChild(near.outer);
+    world.appendChild(far.outer);
+
+    const result = world.getPointsAt(TARGET, AGGREGATE, 1);
+    const visible = visibleWorldRegion();
+
+    for (const canvas of [near, far]) {
+      // The visible region in this canvas's own leaf coordinates.
+      const expected = tilesOverlapping(
+        canvas.leaf,
+        visible.x1 - canvas.contentX,
+        visible.y1 - canvas.contentY,
+        visible.x2 - canvas.contentX,
+        visible.y2 - canvas.contentY
+      );
+      // Both canvases really are partly on screen here -- if this ever
+      // stops holding, the fixture has drifted and the rest of the test
+      // would be vacuous.
+      expect(expected.length).toBeGreaterThan(0);
+
+      const selected = selectedTiles(result, canvas.leaf.label);
+      for (const tile of expected) {
+        expect(selected).toContain(tile);
+      }
+    }
+  });
+
+  test('the far canvas is not reduced to a stray tile or two at one edge', () => {
+    // The specific pre-fix failure, stated as its own guard: the far canvas
+    // did paint -- from the sliver an empty region left behind after being
+    // rotated back into existence -- but from the wrong end of its grid,
+    // missing most of what was on screen. Selecting *something* is not the
+    // bar; selecting what's actually visible is.
+    const world = new World();
+    const far = makeCanvas('far', 2451);
+    world.appendChild(far.outer);
+
+    const visible = visibleWorldRegion();
+    const expected = tilesOverlapping(
+      far.leaf,
+      visible.x1 - far.contentX,
+      visible.y1 - far.contentY,
+      visible.x2 - far.contentX,
+      visible.y2 - far.contentY
+    );
+    const selected = selectedTiles(world.getPointsAt(TARGET, AGGREGATE, 1), 'far-tiles');
+
+    expect(selected.length).toBeGreaterThanOrEqual(expected.length);
+    expect(selected.sort()).toEqual(expect.arrayContaining(expected));
+  });
+
+  test('an already-empty target is never widened back into a real region', () => {
+    // The resurrection step in isolation: an unrotated node whose
+    // *descendant* carries the rotation (so it does widen -- see
+    // selectionRotation) is handed getIntersection's own "these boxes miss
+    // each other" strand by its parent.
+    const owner = WorldObject.createWithProps({ id: 'owner', x: 0, y: 0, width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    const rotated = WorldObject.createWithProps({
+      id: 'rotated',
+      x: 0,
+      y: 0,
+      width: CANVAS_WIDTH,
+      height: CANVAS_HEIGHT,
+      rotation: ROTATION,
+    });
+    const leaf = makeGridLeaf('tiles', CANVAS_WIDTH, CANVAS_HEIGHT);
+    (rotated as any).layers = [leaf];
+    (owner as any).layers = [rotated];
+    // A pivot outside the empty region, which is what makes rotating it
+    // move the region somewhere else rather than leave it in place.
+    const pivot = { x: -621, y: 1686 };
+    owner.rotationPivot = { ...pivot };
+    rotated.rotationPivot = { ...pivot };
+
+    const emptyTarget = dna([0, 0, 0, 0, 0]);
+
+    expect(selectedTiles(owner.getAllPointsAt(emptyTarget, AGGREGATE, 1), 'tiles')).toEqual([]);
+  });
+
+  test('a target touching the object exactly along one edge selects nothing', () => {
+    // getIntersection's overlap test is inclusive, so an edge-touch comes
+    // back flagged as a real intersection -- with zero area. Nothing can be
+    // visible in it, and it must not be widened back into a real region
+    // either.
+    const owner = WorldObject.createWithProps({
+      id: 'owner',
+      x: 0,
+      y: 0,
+      width: CANVAS_WIDTH,
+      height: CANVAS_HEIGHT,
+      rotation: ROTATION,
+    });
+    (owner as any).layers = [makeGridLeaf('tiles', CANVAS_WIDTH, CANVAS_HEIGHT)];
+    owner.rotationPivot = { x: 5000, y: 3000 };
+
+    const edgeTouch = dna([1, CANVAS_WIDTH, 1000, CANVAS_WIDTH, 2000]);
+
+    expect(selectedTiles(owner.getAllPointsAt(edgeTouch, AGGREGATE, 1), 'tiles')).toEqual([]);
+  });
+
+  test('selectionBounds covers a pivot-compensated descendant, and is inert without one', () => {
+    const compensated = makeCanvas('compensated', 2451);
+    expect(Array.from(compensated.outer.selectionBounds())).toEqual([
+      1,
+      2451 + COMPENSATION,
+      COMPENSATION,
+      2451 + CANVAS_WIDTH,
+      CANVAS_HEIGHT,
+    ]);
+
+    const plain = WorldObject.createWithProps({ id: 'plain', x: 10, y: 20, width: 100, height: 200 });
+    const child = WorldObject.createWithProps({ id: 'child', x: 0, y: 0, width: 100, height: 200 });
+    (plain as any).layers = [child];
+    expect(Array.from(plain.selectionBounds())).toEqual(Array.from(plain.points));
+  });
+});

--- a/src/__tests__/modules/world-object-fixed-pivot-position.test.ts
+++ b/src/__tests__/modules/world-object-fixed-pivot-position.test.ts
@@ -1,0 +1,234 @@
+import { WorldObject } from '../../world-objects/world-object';
+import { CanvasRenderer } from '../../modules/canvas-renderer/canvas-renderer';
+
+// Same minimal 2D affine-matrix mock of CanvasRenderingContext2D used in
+// canvas-renderer-rotation.test.ts, tracking only the ops applyTransform() calls.
+function createMatrixCtx() {
+  let m = [1, 0, 0, 1, 0, 0];
+  const multiply = (m1: number[], m2: number[]) => [
+    m1[0] * m2[0] + m1[2] * m2[1],
+    m1[1] * m2[0] + m1[3] * m2[1],
+    m1[0] * m2[2] + m1[2] * m2[3],
+    m1[1] * m2[2] + m1[3] * m2[3],
+    m1[0] * m2[4] + m1[2] * m2[5] + m1[4],
+    m1[1] * m2[4] + m1[3] * m2[5] + m1[5],
+  ];
+  return {
+    save: () => {},
+    restore: () => {},
+    translate(x: number, y: number) {
+      m = multiply(m, [1, 0, 0, 1, x, y]);
+    },
+    rotate(angle: number) {
+      m = multiply(m, [Math.cos(angle), Math.sin(angle), -Math.sin(angle), Math.cos(angle), 0, 0]);
+    },
+    apply(x: number, y: number): [number, number] {
+      return [m[0] * x + m[2] * y + m[4], m[1] * x + m[3] * y + m[5]];
+    },
+  };
+}
+
+// Renders `owner`'s current center through the real CanvasRenderer.applyTransform,
+// using `pivot` (screen-space, matching what Runtime would pass as cx/cy).
+function renderedCenter(owner: WorldObject, pivot: { x: number; y: number } | undefined) {
+  const renderer = Object.create(CanvasRenderer.prototype) as CanvasRenderer;
+  const ctx = createMatrixCtx();
+  (renderer as any).ctx = ctx;
+  const paint = { __owner: { value: owner } } as any;
+
+  // Assume world-space === screen-space here (scaleFactor 1, no pan) so the
+  // test isolates the rotation/positioning math from viewer<->world conversion.
+  renderer.applyTransform(paint, owner.x, owner.y, owner.width, owner.height, pivot?.x as any, pivot?.y as any);
+
+  const rawCenterX = owner.x + owner.width / 2;
+  const rawCenterY = owner.y + owner.height / 2;
+  const [x, y] = ctx.apply(rawCenterX, rawCenterY);
+  return { x, y };
+}
+
+describe('WorldObject position under a fixed (viewport-center) rotation pivot', () => {
+  test('rotation still sweeps the object around the fixed pivot when x/y are unchanged', () => {
+    // This is the core "rotate from viewport center" feature: as rotation
+    // angle changes alone, the object's rendered center must move along an
+    // arc around the pivot, not stay fixed in place.
+    const pivot = { x: 400, y: 300 };
+    const owner = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 0 });
+    owner.rotationPivot = pivot;
+    owner.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 0 });
+
+    const at0 = renderedCenter(owner, pivot);
+
+    owner.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+    const at90 = renderedCenter(owner, pivot);
+
+    // The center must have actually moved (swept around the pivot) -- this
+    // is the opposite of what a naive "always cancel rotation" fix would do.
+    const moved = Math.abs(at90.x - at0.x) > 1 || Math.abs(at90.y - at0.y) > 1;
+    expect(moved).toBe(true);
+  });
+
+  test('at 90deg, changing x moves the rendered position horizontally, not vertically', () => {
+    const pivot = { x: 400, y: 300 };
+    const owner = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+    owner.rotationPivot = pivot;
+    owner.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+
+    const before = renderedCenter(owner, pivot);
+
+    owner.applyProps({ id: 'a', x: 110, y: 80, width: 60, height: 40, rotation: 90 });
+    const after = renderedCenter(owner, pivot);
+
+    expect(after.x - before.x).toBeCloseTo(10);
+    expect(Math.abs(after.y - before.y)).toBeLessThan(0.01);
+  });
+
+  test('at 90deg, changing y moves the rendered position vertically, not horizontally', () => {
+    const pivot = { x: 400, y: 300 };
+    const owner = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+    owner.rotationPivot = pivot;
+    owner.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+
+    const before = renderedCenter(owner, pivot);
+
+    owner.applyProps({ id: 'a', x: 100, y: 90, width: 60, height: 40, rotation: 90 });
+    const after = renderedCenter(owner, pivot);
+
+    expect(Math.abs(after.x - before.x)).toBeLessThan(0.01);
+    expect(after.y - before.y).toBeCloseTo(10);
+  });
+
+  test('without a rotation pivot (own-center mode), x already moves horizontally at any angle', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+    // rotationPivot left undefined -- own-center mode, unaffected by this change.
+
+    const beforeRaw = { x: owner.x, y: owner.y };
+    const before = renderedCenter(owner, undefined);
+
+    owner.applyProps({ id: 'a', x: 110, y: 80, width: 60, height: 40, rotation: 90 });
+    const after = renderedCenter(owner, undefined);
+
+    expect(after.x - before.x).toBeCloseTo(10);
+    expect(Math.abs(after.y - before.y)).toBeLessThan(0.01);
+  });
+
+  test('repeated identical re-renders (unrelated prop changes) do not drift the position', () => {
+    const pivot = { x: 400, y: 300 };
+    const owner = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 45 });
+    owner.rotationPivot = pivot;
+    owner.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 45 });
+
+    const first = renderedCenter(owner, pivot);
+
+    // Re-render several times with the exact same x/y/rotation, as would
+    // happen from unrelated state changes elsewhere in the component tree.
+    for (let i = 0; i < 5; i++) {
+      owner.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 45 });
+    }
+
+    const after = renderedCenter(owner, pivot);
+    expect(after.x).toBeCloseTo(first.x);
+    expect(after.y).toBeCloseTo(first.y);
+  });
+
+  // Regression test for a real bug: the screen-aligned delta un-rotation
+  // above used to read this.rotation -- the angle from *before* this call --
+  // even though this.rotation isn't reassigned to props.rotation until
+  // afterward. A call that changes rotation and x/y together therefore
+  // un-rotated the position delta by the wrong (stale) angle.
+  //
+  // Verified by an equivalence that must hold regardless of how the edit is
+  // split: rotating first and then moving (two separate applyProps calls,
+  // each changing only one thing) must land at the same rendered position
+  // as changing both in a single combined call -- there's nothing about a
+  // single edit event that should make the math order-dependent. The stale
+  // angle breaks exactly this equivalence, since the single-call path ends
+  // up un-rotating by the pre-edit angle while the two-call path always
+  // un-rotates by whatever angle is already current at the time of the
+  // (now angle-only) position-changing call.
+  test('changing rotation and x together in one call lands at the same position as doing it in two', () => {
+    const pivot = { x: 400, y: 300 };
+
+    const twoStep = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 0 });
+    twoStep.rotationPivot = pivot;
+    twoStep.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 0 });
+    twoStep.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+    twoStep.applyProps({ id: 'a', x: 110, y: 80, width: 60, height: 40, rotation: 90 });
+    const twoStepCenter = renderedCenter(twoStep, pivot);
+
+    const oneStep = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 0 });
+    oneStep.rotationPivot = pivot;
+    oneStep.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 0 });
+    oneStep.applyProps({ id: 'a', x: 110, y: 80, width: 60, height: 40, rotation: 90 });
+    const oneStepCenter = renderedCenter(oneStep, pivot);
+
+    expect(oneStepCenter.x).toBeCloseTo(twoStepCenter.x);
+    expect(oneStepCenter.y).toBeCloseTo(twoStepCenter.y);
+  });
+});
+
+describe('WorldObject#applyPivotCompensationOffset keeps screen-aligned editing in sync', () => {
+  // Regression coverage for a real reported bug: Runtime calls
+  // applyPivotCompensationOffset() directly (bypassing applyProps()) both
+  // when toggling own-center/viewport-center mode and when a drag gesture
+  // ends (see Runtime#endInteraction). WorldObject#applyProps's
+  // screen-aligned-edit logic tracks its own lastAppliedX/Y snapshot to
+  // compute deltas on the *next* prop change -- if that snapshot isn't kept
+  // in sync with the direct offset, the next unrelated edit (rotation,
+  // tx, or ty) sees a spurious delta equal to the compensation that was
+  // already applied, and re-applies it a second time, rotated.
+
+  test('a compensation offset does not reappear as a spurious jump on the next unrelated edit', () => {
+    const pivot = { x: 400, y: 300 };
+    const owner = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+    owner.rotationPivot = pivot;
+    owner.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+
+    // Simulates Runtime nudging the object's position directly, as
+    // endInteraction()/compensateRotationPivotChange() do -- not via applyProps.
+    owner.applyPivotCompensationOffset(25, -15);
+
+    const beforeUnrelatedEdit = { x: owner.x, y: owner.y };
+
+    // An unrelated edit: only rotation changes, x/y props are identical to
+    // last time. If lastAppliedX/Y fell out of sync with the compensation
+    // above, this would incorrectly see a deltaX/Y of (25,-15) and shift
+    // the object again.
+    owner.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 95 });
+
+    expect(owner.x).toBeCloseTo(beforeUnrelatedEdit.x);
+    expect(owner.y).toBeCloseTo(beforeUnrelatedEdit.y);
+  });
+
+  test('a compensation offset does not reappear as a spurious jump on the next tx/ty edit', () => {
+    const pivot = { x: 400, y: 300 };
+    const owner = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+    owner.rotationPivot = pivot;
+    owner.applyProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 90 });
+
+    owner.applyPivotCompensationOffset(25, -15);
+
+    // A genuine tx edit of +10 (screen-space, since rotationPivot is set) on
+    // top of the already-compensated position. At 90deg this should read as
+    // a purely vertical raw-position change (matching the existing "moving
+    // x moves vertically at 90deg" behavior), not include any leftover
+    // delta from the compensation.
+    const before = { x: owner.x, y: owner.y };
+    owner.applyProps({ id: 'a', x: 110, y: 80, width: 60, height: 40, rotation: 90 });
+
+    expect(Math.abs(owner.x - before.x)).toBeLessThan(0.01);
+    expect(Math.abs(owner.y - before.y)).toBeCloseTo(10);
+  });
+
+  test('applyPivotCompensationOffset before any applyProps call does not throw and just translates', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 100, y: 80, width: 60, height: 40, rotation: 0 });
+    // Bypass the constructor's own applyProps call by constructing a fresh,
+    // never-applyProps'd instance directly (createWithProps always calls it
+    // once) -- this covers a WorldObject compensated before its first real
+    // prop application, e.g. very early in a mount sequence.
+    const fresh = new (WorldObject as any)();
+    fresh.points = owner.points.slice();
+    fresh.rotation = 0;
+
+    expect(() => fresh.applyPivotCompensationOffset(5, 5)).not.toThrow();
+  });
+});

--- a/src/__tests__/modules/world-object-hit-test-rotation-culling.test.ts
+++ b/src/__tests__/modules/world-object-hit-test-rotation-culling.test.ts
@@ -1,0 +1,234 @@
+import { dna, DnaFactory, Strand } from '@atlas-viewer/dna';
+import { WorldObject, HitTestCullingDebugEvent } from '../../world-objects/world-object';
+
+// getObjectsAt (hit-testing -- world.getObjectsAt() / click and hover
+// targets, called from world.ts's propagatePointerEvent/propagateTouchEvent,
+// fed by browser-event-manager.ts) rotates `target` via applyRotation()
+// before intersecting it with this.points -- superficially the same pattern
+// that was removed from getAllPointsAt (painting) to fix a real reported
+// bug (see world-object-culling.test.ts): a rotationPivot far from the
+// object could rotate a small `target` clean outside this.points, culling
+// something genuinely on screen.
+//
+// It is *not* the same bug here, despite looking identical. The two
+// `target`s mean different things:
+//  - getAllPointsAt's target is the current viewport window. Rotation is a
+//    pure render-time visual effect (see its own comment) that must not
+//    reposition the viewport for culling/tile-selection purposes -- hence
+//    leaving it unrotated was the correct fix.
+//  - getObjectsAt's target is a real click/touch point, always built by its
+//    only callers (world.ts:105/122) as a 1x1 box around the raw,
+//    un-rotated mouse position from browser-event-manager.ts's
+//    viewerToWorld() -- which has no per-object knowledge of rotation at
+//    all. To know whether that raw point lands on this *specific* object's
+//    visually-rotated appearance, getObjectsAt has to map it back into the
+//    object's own local space itself, which is exactly what
+//    applyRotation(target) does (verified below against the real forward
+//    render transform in canvas-renderer.ts#applyTransform).
+//
+// Reusing world-object-culling.test.ts's viewport-shaped target (matching
+// the object's own full un-rotated bounds) against getObjectsAt was
+// comparing the wrong thing -- a real click never looks like that. The
+// tests below use a real point-shaped target instead, and confirm the
+// current rotation-aware behaviour is correct: a click at the object's true
+// (rotated, pivot-swept) on-screen position hits, and a click at its raw
+// un-rotated position -- which is no longer where it visually is -- misses.
+
+// Mirrors canvas-renderer.ts#applyTransform's forward transform exactly:
+// ctx.translate(cx,cy); ctx.rotate(angle); ctx.translate(-cx,-cy). Used
+// here only to compute where a rotated object actually renders, so the
+// tests can click "for real" instead of guessing a target.
+function forwardRenderPosition(cx: number, cy: number, x: number, y: number, angleDeg: number) {
+  const rad = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const dx = x - cx;
+  const dy = y - cy;
+  return { x: cx + (dx * cos - dy * sin), y: cy + (dx * sin + dy * cos) };
+}
+
+describe('WorldObject#debugHitTestCulling hook', () => {
+  afterEach(() => {
+    WorldObject.debugHitTestCulling = undefined;
+  });
+
+  test('does not fire for an unrotated object', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 0, y: 0, width: 200, height: 100, rotation: 0 });
+    const events: HitTestCullingDebugEvent[] = [];
+    WorldObject.debugHitTestCulling = (event) => events.push(event);
+
+    owner.getObjectsAt(DnaFactory.singleBox(1, 1, 50, 25));
+
+    expect(events).toEqual([]);
+  });
+
+  test('fires for a rotated object and reports the target rotated into local space', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 0, y: 0, width: 200, height: 100, rotation: 87 });
+    owner.rotationPivot = { x: 5000, y: 3000 };
+    const events: HitTestCullingDebugEvent[] = [];
+    WorldObject.debugHitTestCulling = (event) => events.push(event);
+
+    const rendered = forwardRenderPosition(5000, 3000, 100, 50, 87);
+    const target = DnaFactory.singleBox(1, 1, rendered.x, rendered.y);
+    owner.getObjectsAt(target);
+
+    expect(events.length).toBe(1);
+    expect(events[0].hasExternalPivot).toBe(true);
+    expect(Array.from(events[0].rawTarget)).toEqual(Array.from(target));
+    // The click was built at the object's *rendered* position, so mapping
+    // it back into local space should land inside this.points -- not culled.
+    expect(events[0].culled).toBe(false);
+  });
+});
+
+describe('WorldObject#getObjectsAt hit-testing a rotated object under a far pivot', () => {
+  afterEach(() => {
+    WorldObject.debugHitTestCulling = undefined;
+  });
+
+  test('a click at the object\'s true (pivot-swept) rendered position registers as a hit', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 0, y: 0, width: 200, height: 100, rotation: 87 });
+    // A rotationPivot far outside the object's own bounds -- e.g. the
+    // viewport center under rotateFromWorldCenter, at a zoom level where
+    // the object is comparatively small and far from that center. Sweeping
+    // the object 87deg around a pivot this far away moves its rendered
+    // position by thousands of units.
+    owner.rotationPivot = { x: 5000, y: 3000 };
+
+    const leaf = { points: dna([1, 0, 0, 200, 100]) } as any;
+    (owner as any).layers = [leaf];
+
+    const centerX = 100;
+    const centerY = 50;
+    const rendered = forwardRenderPosition(5000, 3000, centerX, centerY, 87);
+
+    const events: HitTestCullingDebugEvent[] = [];
+    WorldObject.debugHitTestCulling = (event) => events.push(event);
+
+    const target = DnaFactory.singleBox(1, 1, rendered.x, rendered.y);
+    const result = owner.getObjectsAt(target);
+
+    expect(events[0].culled).toBe(false);
+    expect(result.length).toBe(1);
+  });
+
+  test('a click at the object\'s raw un-rotated position misses, since it visually swept away', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 0, y: 0, width: 200, height: 100, rotation: 87 });
+    owner.rotationPivot = { x: 5000, y: 3000 };
+
+    const leaf = { points: dna([1, 0, 0, 200, 100]) } as any;
+    (owner as any).layers = [leaf];
+
+    const events: HitTestCullingDebugEvent[] = [];
+    WorldObject.debugHitTestCulling = (event) => events.push(event);
+
+    // The object's own center, un-rotated -- where a click would need to
+    // land if rotation were (incorrectly) ignored entirely.
+    const target = DnaFactory.singleBox(1, 1, 100, 50);
+    const result = owner.getObjectsAt(target);
+
+    expect(events[0].culled).toBe(true);
+    expect(result.length).toBe(0);
+  });
+
+  test('a target genuinely nowhere near the object, rotated or not, is still culled', () => {
+    const owner = WorldObject.createWithProps({ id: 'a', x: 0, y: 0, width: 200, height: 100, rotation: 87 });
+    owner.rotationPivot = { x: 5000, y: 3000 };
+
+    const leaf = { points: dna([1, 0, 0, 200, 100]) } as any;
+    (owner as any).layers = [leaf];
+
+    const events: HitTestCullingDebugEvent[] = [];
+    WorldObject.debugHitTestCulling = (event) => events.push(event);
+
+    const target = DnaFactory.singleBox(1, 1, 999999, 999999);
+    const result = owner.getObjectsAt(target);
+
+    expect(events[0].culled).toBe(true);
+    expect(result.length).toBe(0);
+  });
+});
+
+// Regression fixture for a second, real bug in the same family: getObjectsAt
+// (this file's own subject) never received the fix that made getAllPointsAt
+// (painting) correct for a pivot-compensated descendant -- see
+// WorldObject#selectionBounds's own comment. Runtime#syncRotationPivotPosition
+// moves only the actually-rotated node (`if (owner.rotation)`); an unrotated
+// ancestor's own `this.points` is left describing where its content *used*
+// to be. getAllPointsAt was fixed to intersect against selectionBounds()
+// instead; getObjectsAt (this file) still culled against raw this.points,
+// so a click on content that paints correctly (via the already-fixed
+// getAllPointsAt) could still be silently rejected before ever reaching the
+// descendant whose own hit-test would have found it.
+describe('WorldObject#getObjectsAt reaches a pivot-compensated descendant through unrotated ancestors', () => {
+  afterEach(() => {
+    WorldObject.debugHitTestCulling = undefined;
+  });
+
+  // outer (rotation 0, points never updated) -> inner (rotation 0, same) ->
+  // rotated (rotation 90, shifted via x/y the way
+  // Runtime#syncRotationPivotPosition/applyPivotCompensationOffset actually
+  // moves a rotated node -- see world-object.ts's own comment on
+  // applyPivotCompensationOffset) -> leaf.
+  function makeCompensatedFixture() {
+    // Shifted -80 on both axes: half of this now falls outside outer/
+    // inner's original, never-updated [0,0,200,100] bounds.
+    const rotated = WorldObject.createWithProps({ id: 'rotated', x: -80, y: -80, width: 200, height: 100, rotation: 90 });
+    // getObjectsAt(target, all: true) recurses into every layer via
+    // layer.getObjectsAt regardless of whether it's a WorldObject or a leaf
+    // (BaseObject#getObjectsAt gives every leaf type this same no-op
+    // default), so the fake leaf needs one too.
+    const leaf = { points: dna([1, 0, 0, 200, 100]), getObjectsAt: () => [] } as any;
+    (rotated as any).layers = [leaf];
+
+    const inner = WorldObject.createWithProps({ id: 'inner', x: 0, y: 0, width: 200, height: 100 });
+    (inner as any).layers = [rotated];
+
+    const outer = WorldObject.createWithProps({ id: 'outer', x: 0, y: 0, width: 200, height: 100 });
+    (outer as any).layers = [inner];
+
+    return { outer, inner, rotated, leaf };
+  }
+
+  test('a click at the compensated descendant\'s own center reaches it through two stale-bounds ancestors', () => {
+    const { outer, rotated } = makeCompensatedFixture();
+
+    // rotated.points is [-80,-80,120,20] (center at (20,-30)) -- outside
+    // outer/inner's original y range of [0,100]. Rotation around a node's
+    // own center is a fixed point of the rotation for any angle, so this
+    // target requires no render-transform bookkeeping to construct: it maps
+    // to itself through rotated.applyRotation() regardless of the 90deg
+    // angle, isolating this test to the ancestor-staleness fix rather than
+    // re-testing applyRotation's own math (already covered above).
+    const centerX = (rotated.points[1] + rotated.points[3]) / 2;
+    const centerY = (rotated.points[2] + rotated.points[4]) / 2;
+    expect(centerY).toBeLessThan(0); // sanity: genuinely outside the stale ancestor bounds
+
+    const events: HitTestCullingDebugEvent[] = [];
+    WorldObject.debugHitTestCulling = (event) => events.push(event);
+
+    const target = DnaFactory.singleBox(1, 1, centerX, centerY);
+    const result = outer.getObjectsAt(target, true);
+
+    expect(result.length).toBeGreaterThan(0);
+    // The debug hook now fires (and reports culled: false) from the
+    // unrotated outer ancestor too, not only from the directly-rotated
+    // node -- see the widened-condition comment in getObjectsAt.
+    expect(events.some((e) => e.ownerId === 'outer' && e.culled === false)).toBe(true);
+  });
+
+  test('a click genuinely outside even the widened bounds is still culled at the outer ancestor', () => {
+    const { outer } = makeCompensatedFixture();
+
+    const events: HitTestCullingDebugEvent[] = [];
+    WorldObject.debugHitTestCulling = (event) => events.push(event);
+
+    // selectionBounds() for this fixture is [-80,-80,200,100] -- comfortably
+    // outside that, in both x and y.
+    const target = DnaFactory.singleBox(1, 1, 999999, 999999);
+    const result = outer.getObjectsAt(target, true);
+
+    expect(result.length).toBe(0);
+    expect(events.some((e) => e.ownerId === 'outer' && e.culled === true)).toBe(true);
+  });
+});

--- a/src/__tests__/modules/world-object-nested-rotation-selection.test.ts
+++ b/src/__tests__/modules/world-object-nested-rotation-selection.test.ts
@@ -1,0 +1,146 @@
+import { dna, hidePointsOutsideRegion, Strand } from '@atlas-viewer/dna';
+import { WorldObject, TileSelectionDebugEvent } from '../../world-objects/world-object';
+
+// Regression fixture for a second, real, visually-reported instance of the
+// same blur bug world-object-rotated-tile-selection.test.ts fixes -- this
+// time surviving that fix. Repro: stories/sequence-panel.stories.tsx --
+// Next, Rotate Canvas From Center, Zoom In until it disables. Root cause:
+// getAllPointsAt()'s rotation-aware widening only triggered when *the node
+// running it* was rotated (this.rotation). But render-time rotation is
+// applied by whichever WorldObject is the nearest owner of the paint (see
+// CanvasRenderer#applyTransform) -- which, confirmed live against the real
+// story, was two plain <world-object> levels *above* the node that actually
+// carries the rotation (ImageService renders its rotation onto its own
+// nested wrapper -- see TileSet.tsx). Both of those unrotated ancestors had
+// this.rotation === 0, so their own getAllPointsAt skipped widening
+// entirely (applyRotation is a no-op when rotation is falsy) and handed
+// their child an already-narrowed, zero-rotation-aware target. No amount of
+// the *rotated descendant's own* correct widening can recover content
+// already clipped away by an ancestor's getIntersection higher up the tree
+// -- confirmed live via paint instrumentation: of a 3x4 native-resolution
+// tile grid, only a single tile was ever selected, the rest permanently
+// showing a coarser, visibly blurry fallback layer.
+//
+// Fixed by WorldObject#selectionRotation(): getAllPointsAt widens using
+// this.rotation if set, otherwise recurses into its own children looking
+// for a rotation to widen with instead -- see its own comment for why this
+// has to recurse (not just check direct children) to see through however
+// many unrotated wrapper levels separate a story's own <world-object> from
+// wherever a component like ImageService actually applies the rotation.
+
+// Minimal target-aware leaf, mirroring TiledImage#getAllPointsAt: it
+// actually consults `target` via hidePointsOutsideRegion, so we can tell
+// which leaf(s) a given target would keep. Same pattern already used in
+// world-object-rotated-tile-selection.test.ts.
+function makeFakeLeaf(label: string, points: Strand) {
+  return {
+    label,
+    points,
+    getAllPointsAt(target: Strand, aggregate?: Strand) {
+      return [[this, hidePointsOutsideRegion(points, target), aggregate]];
+    },
+  } as any;
+}
+
+function isSelected(points: Strand) {
+  return points[0] !== 0;
+}
+
+// outer (rotation 0) -> inner (rotation 0) -> rotated (rotation 90) -> [edge, rest].
+// Same 400x400 page-split-into-an-edge-strip fixture as
+// world-object-rotated-tile-selection.test.ts, just reached through two
+// unrotated wrapper levels instead of directly -- matching the real story's
+// own tree shape (<world-object> -> ImageService's own outer wrapper ->
+// ImageService's *nested*, actually-rotated wrapper -- see TileSet.tsx).
+function makeNestedFixture() {
+  const rotated = WorldObject.createWithProps({ id: 'rotated', x: 0, y: 0, width: 400, height: 400, rotation: 90 });
+  const edge = makeFakeLeaf('edge', dna([1, 0, 0, 40, 400]));
+  const rest = makeFakeLeaf('rest', dna([1, 40, 0, 400, 400]));
+  (rotated as any).layers = [edge, rest];
+
+  const inner = WorldObject.createWithProps({ id: 'inner', x: 0, y: 0, width: 400, height: 400, rotation: 0 });
+  (inner as any).layers = [rotated];
+
+  const outer = WorldObject.createWithProps({ id: 'outer', x: 0, y: 0, width: 400, height: 400, rotation: 0 });
+  (outer as any).layers = [inner];
+
+  return { outer, inner, rotated, edge, rest };
+}
+
+describe('WorldObject#selectionRotation (rotation carried by a descendant, not this node)', () => {
+  afterEach(() => {
+    WorldObject.debugTileSelection = undefined;
+  });
+
+  test('an unrotated node reports its rotated descendant\'s angle, not 0', () => {
+    const { outer, inner, rotated } = makeNestedFixture();
+
+    expect((outer as any).selectionRotation()).toBe(90);
+    expect((inner as any).selectionRotation()).toBe(90);
+    expect((rotated as any).selectionRotation()).toBe(90);
+  });
+
+  test('a node with no rotated descendants anywhere reports 0', () => {
+    const outer = WorldObject.createWithProps({ id: 'outer', x: 0, y: 0, width: 400, height: 400, rotation: 0 });
+    const inner = WorldObject.createWithProps({ id: 'inner', x: 0, y: 0, width: 400, height: 400, rotation: 0 });
+    (outer as any).layers = [inner];
+    (inner as any).layers = [makeFakeLeaf('leaf', dna([1, 0, 0, 400, 400]))];
+
+    expect((outer as any).selectionRotation()).toBe(0);
+  });
+
+  test('debugTileSelection fires from the unrotated ancestor, reporting the descendant\'s rotation', () => {
+    const { outer } = makeNestedFixture();
+    const events: TileSelectionDebugEvent[] = [];
+    WorldObject.debugTileSelection = (event) => events.push(event);
+
+    outer.getAllPointsAt(dna([1, 0, 0, 40, 400]), dna([1, 0, 0, 0, 0, 1, 0, 0, 1]), 1);
+
+    // Fires once per level of the tree (outer -> inner -> rotated all widen
+    // and recurse), so three events for this three-deep fixture -- the
+    // point being tested is the *first* of them: outer, despite its own
+    // this.rotation being 0, reports its descendant's angle instead of
+    // silently skipping the hook the way an unwidened node would.
+    expect(events.length).toBe(3);
+    expect(events[0].ownerId).toBe('outer');
+    expect(events[0].rotation).toBe(90);
+    expect(events.map((e) => e.rotation)).toEqual([90, 90, 90]);
+  });
+
+  test('a tight, rotated target reaches the rotated descendant\'s far leaf through two unrotated ancestors', () => {
+    const { outer } = makeNestedFixture();
+    const events: TileSelectionDebugEvent[] = [];
+    WorldObject.debugTileSelection = (event) => events.push(event);
+
+    // Same tight window as world-object-rotated-tile-selection.test.ts: read
+    // literally against the unrotated target alone, this only overlaps
+    // "edge". Without selectionRotation(), outer.rotation === 0 means
+    // outer's own getAllPointsAt never widens at all, and "rest" -- the leaf
+    // physically on screen at this target once the *descendant's* rotation
+    // is accounted for -- never gets a chance to be selected no matter what
+    // `rotated` itself would have done with a wider target.
+    const target = dna([1, 0, 0, 40, 400]);
+    const result = outer.getAllPointsAt(target, dna([1, 0, 0, 0, 0, 1, 0, 0, 1]), 1);
+
+    const actuallySelected = result
+      .filter(([, points]: any) => isSelected(points))
+      .map(([leaf]: any) => leaf.label)
+      .sort();
+
+    expect(actuallySelected).toEqual(['edge', 'rest']);
+  });
+
+  test('an unrotated node with no rotated descendants keeps the original conservative (unwidened) selection', () => {
+    const outer = WorldObject.createWithProps({ id: 'outer', x: 0, y: 0, width: 400, height: 400, rotation: 0 });
+    const edge = makeFakeLeaf('edge', dna([1, 0, 0, 40, 400]));
+    const rest = makeFakeLeaf('rest', dna([1, 40, 0, 400, 400]));
+    (outer as any).layers = [edge, rest];
+
+    const target = dna([1, 0, 0, 40, 400]);
+    const result = outer.getAllPointsAt(target, dna([1, 0, 0, 0, 0, 1, 0, 0, 1]), 1);
+
+    const actuallySelected = result.filter(([, points]: any) => isSelected(points)).map(([leaf]: any) => leaf.label);
+
+    expect(actuallySelected).toEqual(['edge']);
+  });
+});

--- a/src/__tests__/modules/world-object-rotated-tile-selection.test.ts
+++ b/src/__tests__/modules/world-object-rotated-tile-selection.test.ts
@@ -1,0 +1,158 @@
+import { dna, hidePointsOutsideRegion, Strand } from '@atlas-viewer/dna';
+import { WorldObject, TileSelectionDebugEvent } from '../../world-objects/world-object';
+
+// Regression fixture for a real, visually-reported bug: after rotating a
+// zoomed-in canvas (see stories/sequence-panel.stories.tsx -- Next, Zoom In
+// x3, Rotate once), the edge of the page nearest the rotation renders
+// visibly blurrier than the rest, because a lower-resolution fallback layer
+// is what's actually painted there. Root cause: getAllPointsAt() selected
+// *which* content/tile to fetch using only the raw, unrotated `target` (see
+// its own comment -- that's intentional, fixing a different bug where a far
+// rotationPivot caused rotated objects to vanish entirely). That was correct
+// for the yes/no "is this object visible" question, but once zoomed in
+// tight, the raw target no longer identifies the physically-correct
+// sub-region of a *rotated* object, and a leaf that should be selected got
+// skipped -- so nothing at the requested resolution covered that patch of
+// screen, and a coarser fallback layer showed through instead.
+//
+// Fixed by selecting content against the union of target and
+// applyRotation(target) in one pass -- see getAllPointsAt. Extending the
+// selected region can only add coverage, never remove it, so the far-pivot
+// invisibility fix above is untouched; it just also covers whatever the
+// unrotated target alone missed.
+//
+// An earlier version of this fix ran two *separate* getAllPointsAt passes
+// (unrotated, then rotation-aware) and concatenated their results, which
+// introduced its own real bug: each pass does its own coarse-to-fine layer
+// selection and paint ordering, correct within itself, but nothing ordered
+// the two passes against each other, so the second pass's coarse fallback
+// tiles could paint after -- and so visibly overwrite -- the first pass's
+// already-fine tile at the same screen position. A single selection pass
+// against the union has only one coarse-to-fine ordering, so that can't
+// happen; see 'a single selection pass never selects the same leaf twice'
+// below.
+
+// Minimal target-aware leaf, mirroring TiledImage#getAllPointsAt: it
+// actually consults `target` via hidePointsOutsideRegion, so we can tell
+// which leaf(s) a given target would keep. Same pattern already used in
+// world-object-culling.test.ts.
+function makeFakeLeaf(label: string, points: Strand) {
+  return {
+    label,
+    points,
+    getAllPointsAt(target: Strand, aggregate?: Strand) {
+      return [[this, hidePointsOutsideRegion(points, target), aggregate]];
+    },
+  } as any;
+}
+
+function isSelected(points: Strand) {
+  return points[0] !== 0;
+}
+
+describe('WorldObject#debugTileSelection hook', () => {
+  afterEach(() => {
+    WorldObject.debugTileSelection = undefined;
+  });
+
+  test('does not fire for an unrotated object', () => {
+    const owner = WorldObject.createWithProps({ id: 'page', x: 0, y: 0, width: 400, height: 400, rotation: 0 });
+    const events: TileSelectionDebugEvent[] = [];
+    WorldObject.debugTileSelection = (event) => events.push(event);
+
+    owner.getAllPointsAt(dna([1, 0, 0, 200, 400]), dna([1, 0, 0, 0, 0, 1, 0, 0, 1]), 1);
+
+    expect(events).toEqual([]);
+  });
+
+  test('fires for a rotated object and reports a rotation-aware target that differs from the raw one', () => {
+    const owner = WorldObject.createWithProps({ id: 'page', x: 0, y: 0, width: 400, height: 400, rotation: 90 });
+    const events: TileSelectionDebugEvent[] = [];
+    WorldObject.debugTileSelection = (event) => events.push(event);
+
+    const target = dna([1, 0, 0, 200, 400]);
+    owner.getAllPointsAt(target, dna([1, 0, 0, 0, 0, 1, 0, 0, 1]), 1);
+
+    expect(events.length).toBe(1);
+    expect(Array.from(events[0].rawTarget)).toEqual(Array.from(target));
+    // If these matched, there'd be nothing for a test to detect below.
+    expect(Array.from(events[0].rotationAwareTarget)).not.toEqual(Array.from(events[0].rawTarget));
+  });
+});
+
+describe('WorldObject#getAllPointsAt tile selection near a rotated edge (reproduces the reported blur)', () => {
+  afterEach(() => {
+    WorldObject.debugTileSelection = undefined;
+  });
+
+  test('the leaves selected for a tight, rotated target cover what a rotation-aware selection would pick', () => {
+    // A 400x400 page split into a thin "edge" strip (mirroring the margin
+    // that rendered blurry in the story) and the rest of the page.
+    const owner = WorldObject.createWithProps({ id: 'page', x: 0, y: 0, width: 400, height: 400, rotation: 90 });
+    const edge = makeFakeLeaf('edge', dna([1, 0, 0, 40, 400]));
+    const rest = makeFakeLeaf('rest', dna([1, 40, 0, 400, 400]));
+    (owner as any).layers = [edge, rest];
+
+    const events: TileSelectionDebugEvent[] = [];
+    WorldObject.debugTileSelection = (event) => events.push(event);
+
+    // Zoomed tightly into a window that, read literally against the
+    // unrotated target alone, overlaps only "edge".
+    const target = dna([1, 0, 0, 40, 400]);
+    const result = owner.getAllPointsAt(target, dna([1, 0, 0, 0, 0, 1, 0, 0, 1]), 1);
+
+    const actuallySelected = result
+      .filter(([, points]: any) => isSelected(points))
+      .map(([leaf]: any) => leaf.label)
+      .sort();
+
+    // What a rotation-aware selection alone would have picked, computed
+    // independently (not by calling getAllPointsAt again) against the
+    // rotationAwareTarget the hook just reported.
+    const rotationAwareTarget = events[0].rotationAwareTarget;
+    const physicallyExpected = [edge, rest]
+      .filter((leaf) => isSelected(hidePointsOutsideRegion(leaf.points, rotationAwareTarget)))
+      .map((leaf) => leaf.label)
+      .sort();
+
+    // Fixed: getAllPointsAt now selects against target ∪ rotationAwareTarget,
+    // so "rest" -- the leaf that's physically on screen at this target once
+    // rotation is accounted for -- is selected alongside "edge" (the
+    // unrotated pass's conservative baseline, kept for the far-pivot
+    // guarantee). `actuallySelected` covers everything `physicallyExpected`
+    // says should be visible.
+    for (const label of physicallyExpected) {
+      expect(actuallySelected).toContain(label);
+    }
+  });
+
+  test('a single selection pass never selects the same leaf twice', () => {
+    // Regression guard for the real bug the union-based fix above replaced:
+    // running getAllPointsAt against target and applyRotation(target) as
+    // two *separate* passes and concatenating them could select (and then
+    // paint) the same leaf twice, with no guarantee the second pass's own
+    // coarse-to-fine ordering wouldn't land a lower-resolution draw after
+    // the first pass's already-fine one at the same screen position --
+    // confirmed live via drawImage instrumentation against the real story,
+    // watching several render ticks after rotating (dozens of overwritten-
+    // tile cases). Asserting exactly one
+    // result per leaf is what actually guarantees that can't recur: with
+    // only one selection pass, there is only one coarse-to-fine paint
+    // order.
+    const owner = WorldObject.createWithProps({ id: 'page', x: 0, y: 0, width: 400, height: 400, rotation: 90 });
+    const edge = makeFakeLeaf('edge', dna([1, 0, 0, 40, 400]));
+    const rest = makeFakeLeaf('rest', dna([1, 40, 0, 400, 400]));
+    (owner as any).layers = [edge, rest];
+
+    // A target whose rotation-aware counterpart overlaps a *different*
+    // region than the raw target (same setup as the test above, where both
+    // leaves end up selected) -- the case most likely to double-select if
+    // the old two-pass approach were still in use.
+    const target = dna([1, 0, 0, 40, 400]);
+    const result = owner.getAllPointsAt(target, dna([1, 0, 0, 0, 0, 1, 0, 0, 1]), 1);
+
+    const selectedLabels = result.filter(([, points]: any) => isSelected(points)).map(([leaf]: any) => leaf.label);
+    const uniqueLabels = new Set(selectedLabels);
+    expect(selectedLabels.length).toBe(uniqueLabels.size);
+  });
+});

--- a/src/__tests__/modules/world-object-selection-bounds-scale.test.ts
+++ b/src/__tests__/modules/world-object-selection-bounds-scale.test.ts
@@ -1,0 +1,67 @@
+import { WorldObject } from '../../world-objects/world-object';
+
+// Regression coverage for a real test-coverage gap: every rotation/pivot
+// fixture across the whole rotation test suite used the default scale of 1
+// (grep confirms zero non-default `scale` usages anywhere in
+// world-object-*.test.ts / world-far-rotated-object-selection.test.ts /
+// runtime-*.test.ts), even though WorldObject#selectionBounds multiplies a
+// child's bounds by this.scale before merging, and Runtime's pivot-tracking
+// tree-walk (updateWorldObjectRotationPivots / syncRotationPivotPosition)
+// accumulates parentScale * owner.scale down the tree. A wrong order of
+// operations or wrong axis in either would have shipped silently.
+//
+// Values below are deliberately asymmetric (different x vs y, different
+// width vs height, a non-trivial scale) so that an axis swap or a missing
+// multiplication produces a numerically different, easy-to-spot result
+// rather than accidentally matching by coincidence.
+
+describe('WorldObject#selectionBounds scales a child\'s contribution by this.scale', () => {
+  test('a scaled parent widens by the child bounds scaled down, not the raw child bounds', () => {
+    // Parent scaled to 0.25 -- WorldObject#applyProps mutates .points to
+    // already reflect that scale (a 400x120 object at scale 0.25 ends up
+    // with points width/height 100x30), so parent.points itself is already
+    // correct; what this test isolates is the *child's* contribution.
+    const parent = WorldObject.createWithProps({ id: 'parent', x: 0, y: 0, width: 400, height: 120, scale: 0.25 });
+    expect(Array.from(parent.points)).toEqual([1, 0, 0, 100, 30]);
+
+    // A child positioned and sized well outside the parent's own [0,0,100,30]
+    // -- in the child's own local (pre-parent-scale) frame.
+    const child = WorldObject.createWithProps({ id: 'child', x: 40, y: 200, width: 60, height: 20 });
+    (parent as any).layers = [child];
+
+    // child's own bounds: [40, 200, 100, 220]. Scaled by parent.scale=0.25
+    // and offset by parent.x/y=0: [10, 50, 25, 55]. Unioned with parent's
+    // own [0,0,100,30]: x2/y2 come from the child (25 < 100 is false for x2
+    // since parent's own x2=100 is larger, but y2=55 > 30 -- only the y
+    // axis should actually widen here, which is exactly what an axis-swap
+    // bug would get wrong).
+    const bounds = parent.selectionBounds();
+    expect(Array.from(bounds)).toEqual([1, 0, 0, 100, 55]);
+  });
+
+  test('nested scaling compounds multiplicatively, not additively', () => {
+    // outer(scale=0.5) -> inner(scale=0.5): a point at inner-local (100, 0)
+    // must land at outer-local (25, 0) -- 100 * 0.5 (inner's own, applied
+    // when inner computes its own bounds relative to itself -- inapplicable
+    // here since the probe point IS inner's own extent) * 0.5 (outer's) --
+    // i.e. compounding by multiplication (0.25 total), not by adding the
+    // two scale factors (which would give an incorrect 0.0 or 1.0 style
+    // result depending on the mistake).
+    const outer = WorldObject.createWithProps({ id: 'outer', x: 0, y: 0, width: 10, height: 10, scale: 0.5 });
+    const inner = WorldObject.createWithProps({ id: 'inner', x: 0, y: 0, width: 200, height: 10, scale: 0.5 });
+    (outer as any).layers = [inner];
+
+    // inner.points is already [0,0,100,5] (200x10 at its own scale 0.5).
+    expect(Array.from(inner.points)).toEqual([1, 0, 0, 100, 5]);
+
+    // outer's own bounds [0,0,5,5] (10x10 at scale 0.5) unioned with
+    // inner's [0,0,100,5] scaled by outer.scale=0.5 -> [0,0,50,2.5] ->
+    // outer's x2 must be 50 (100 * 0.5), not 100 (unscaled) or 25 (an
+    // additive 0.5+0.5=1... no -- distinguishing multiplicative compounding
+    // requires comparing against the single-level-scale test above: if
+    // outer's own scale were mistakenly ignored for the child merge, x2
+    // would come out as 100 instead of 50).
+    const bounds = outer.selectionBounds();
+    expect(bounds[3]).toBeCloseTo(50);
+  });
+});

--- a/src/__tests__/modules/world-object-selection-rotation-and-bounds.test.ts
+++ b/src/__tests__/modules/world-object-selection-rotation-and-bounds.test.ts
@@ -1,0 +1,71 @@
+import { WorldObject } from '../../world-objects/world-object';
+
+// getAllPointsAt used to call selectionRotation() and selectionBounds()
+// separately, each independently walking this node's entire child subtree
+// -- real, measurable redundant work on a hot per-frame path (see
+// selectionRotationAndBounds's own comment). It was merged into one
+// combined walk purely as an internal optimization: this test exists to
+// guarantee that merge didn't change any observable value -- the combined
+// method must always agree with what the two separate public methods
+// would have computed independently, for both a plain tree and one with a
+// pivot-compensated (and so widened) descendant.
+
+function makeCompensatedFixture() {
+  const rotated = WorldObject.createWithProps({ id: 'rotated', x: -80, y: -80, width: 200, height: 100, rotation: 90 });
+  const leaf = { points: (rotated as any).points, rotation: 0 } as any;
+  (rotated as any).layers = [leaf];
+
+  const inner = WorldObject.createWithProps({ id: 'inner', x: 0, y: 0, width: 200, height: 100 });
+  (inner as any).layers = [rotated];
+
+  const outer = WorldObject.createWithProps({ id: 'outer', x: 0, y: 0, width: 200, height: 100 });
+  (outer as any).layers = [inner];
+
+  return outer;
+}
+
+describe('WorldObject#selectionRotationAndBounds agrees with the separate public methods', () => {
+  test('a plain, unrotated tree with no rotated descendants', () => {
+    const outer = WorldObject.createWithProps({ id: 'outer', x: 10, y: 20, width: 100, height: 50 });
+    const inner = WorldObject.createWithProps({ id: 'inner', x: 0, y: 0, width: 100, height: 50 });
+    (outer as any).layers = [inner];
+
+    const combined = (outer as any).selectionRotationAndBounds();
+
+    expect(combined.rotation).toBe(outer.selectionRotation());
+    expect(Array.from(combined.bounds)).toEqual(Array.from(outer.selectionBounds()));
+  });
+
+  test('a tree with a pivot-compensated, rotated descendant reached through unrotated ancestors', () => {
+    const outer = makeCompensatedFixture();
+
+    // Read selectionRotation()/selectionBounds() *first*, independently,
+    // before selectionRotationAndBounds() has a chance to run and
+    // overwrite any shared buffer -- isolates this from the buffer-reuse
+    // mechanics being tested, not just their end values.
+    const expectedRotation = outer.selectionRotation();
+    const expectedBounds = Array.from(outer.selectionBounds());
+
+    const combined = (outer as any).selectionRotationAndBounds();
+
+    expect(combined.rotation).toBe(expectedRotation);
+    expect(combined.rotation).toBe(90);
+    expect(Array.from(combined.bounds)).toEqual(expectedBounds);
+    expect(Array.from(combined.bounds)).toEqual([1, -80, -80, 200, 100]);
+  });
+
+  test('a leaf contributing only a bare .rotation property (no selectionRotation/selectionBounds of its own)', () => {
+    const outer = WorldObject.createWithProps({ id: 'outer', x: 0, y: 0, width: 100, height: 100 });
+    const leaf = { points: (outer as any).points, rotation: 42 } as any;
+    (outer as any).layers = [leaf];
+
+    const combined = (outer as any).selectionRotationAndBounds();
+
+    expect(combined.rotation).toBe(42);
+    expect(combined.rotation).toBe(outer.selectionRotation());
+    // A leaf's own rotation contributes to widening but never to bounds --
+    // matches selectionBounds()'s existing behavior of skipping anything
+    // without its own selectionBounds method.
+    expect(Array.from(combined.bounds)).toEqual(Array.from(outer.points));
+  });
+});

--- a/src/__tests__/utility/defer-to-microtask.test.ts
+++ b/src/__tests__/utility/defer-to-microtask.test.ts
@@ -1,0 +1,57 @@
+import { deferToMicrotask } from '../../utility/defer-to-microtask';
+
+// This is the double-invoke guard usePreset relies on to survive React
+// StrictMode's synchronous mount -> cleanup -> mount, tested here in
+// isolation from React entirely -- StrictMode's own double-invoke is
+// synchronous (finishes well before any microtask runs), so the two
+// behaviours that matter are exactly what these tests cover directly:
+// deferral past a microtask, and cancellation before it fires.
+describe('deferToMicrotask', () => {
+  test('runs fn on a later microtask, not synchronously', () => {
+    const fn = vi.fn();
+    deferToMicrotask(fn);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test('runs fn once the microtask queue drains', async () => {
+    const fn = vi.fn();
+    deferToMicrotask(fn);
+    await Promise.resolve();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancelling before the microtask fires prevents fn from ever running', async () => {
+    const fn = vi.fn();
+    const cancel = deferToMicrotask(fn);
+    cancel();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test('cancelling after the microtask already fired is a harmless no-op', async () => {
+    const fn = vi.fn();
+    const cancel = deferToMicrotask(fn);
+    await Promise.resolve();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    cancel();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('mirrors StrictMode double-invoke: first deferred call cancelled before it fires, second one runs', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const cancelFirst = deferToMicrotask(first);
+    // Synchronous cleanup + remount, exactly like StrictMode -- both
+    // happen before the first deferred call's microtask ever runs.
+    cancelFirst();
+    deferToMicrotask(second);
+
+    await Promise.resolve();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/canvas-renderer/canvas-renderer.ts
+++ b/src/modules/canvas-renderer/canvas-renderer.ts
@@ -96,7 +96,135 @@ type InFlightTileLoad = {
 const imageCache = new Map<string, HTMLImageElement>();
 const hostCache: Record<string, any> = {};
 
+export type ImageStretchDebugEvent = {
+  /** The URL requested for this tile/image, as returned by paint.getImageUrl(index). */
+  url: string;
+  /** The loaded HTMLImageElement's actual intrinsic pixel dimensions. */
+  naturalWidth: number;
+  naturalHeight: number;
+  /** The tile's target canvas dimensions -- what drawImage stretches/squashes the loaded image into. */
+  targetWidth: number;
+  targetHeight: number;
+  /**
+   * The tile's position (paint.display.points[index]'s x1/y1), in the same
+   * local coordinate space as the owning SingleImage/TiledImage's own
+   * width/height -- e.g. what a debug overlay would use to place a label
+   * directly over this specific tile.
+   */
+  x: number;
+  y: number;
+  /** paint.id -- identifies which SpacialContent (SingleImage/TiledImage) this tile belongs to. */
+  paintId: string;
+  /** Index into paint.display.points -- which specific tile, for a TiledImage's grid (always 0 for a SingleImage). */
+  index: number;
+  /** True if the source and target aspect ratios differ beyond isImageStretched's tolerance -- the drawn image will look visibly non-uniformly scaled, not just soft/blurry. */
+  stretched: boolean;
+  /**
+   * Whether paint is currently in this.visible -- the same list the
+   * renderer itself consults for painting decisions. A tile can finish
+   * loading and get drawn (firing this event) well after it's scrolled or
+   * zoomed off screen; this lets debug tooling tell a currently-relevant
+   * distortion apart from a stale one nobody will ever see.
+   */
+  isVisible: boolean;
+};
+
+export type TileLoadDebugEvent = {
+  /** paint.id -- identifies which SpacialContent (SingleImage/TiledImage) this tile belongs to. */
+  paintId: string;
+  /** Index into paint.display.points -- which specific tile, for a TiledImage's grid (always 0 for a SingleImage). */
+  index: number;
+  /** paint.display.scale -- the tile's pyramid scale factor (1 = native resolution). */
+  scale: number;
+  /** The URL requested for this tile, as returned by paint.getImageUrl(index). */
+  url: string;
+  /**
+   * 'requested' fires when the network fetch actually starts
+   * (schedulePaintToCanvas's queued task running, not just being enqueued).
+   * 'loaded' fires once the image has decoded and been drawn into its
+   * tile's canvas. 'failed' fires once schedulePaintToCanvas's own retry
+   * policy (imageLoadingConfig.maxAttempts) has given up for good -- not on
+   * every individual failed attempt, only the terminal one.
+   */
+  status: 'requested' | 'loaded' | 'failed';
+};
+
+/**
+ * Pure aspect-ratio comparison backing the debugImageStretch hook below --
+ * exported so tests can call it directly without going through image
+ * loading. Compares aspect ratios, not raw dimensions: drawImage(image, 0,
+ * 0, targetWidth, targetHeight) always scales uniformly if the source and
+ * target share an aspect ratio, even when the absolute pixel counts differ
+ * (e.g. a server returning 1023px for a requested 1024px, common off-by-one
+ * rounding) -- that's just a slightly softer/sharper image, not distortion.
+ * Only a genuine aspect-ratio mismatch produces visible stretching/squashing
+ * (non-uniform scaling), which is what this flags.
+ */
+export function isImageStretched(
+  naturalWidth: number,
+  naturalHeight: number,
+  targetWidth: number,
+  targetHeight: number,
+  tolerance = 0.01
+): boolean {
+  if (!naturalWidth || !naturalHeight || !targetWidth || !targetHeight) {
+    return false;
+  }
+  const sourceRatio = naturalWidth / naturalHeight;
+  const targetRatio = targetWidth / targetHeight;
+  return Math.abs(sourceRatio - targetRatio) / sourceRatio > tolerance;
+}
+
+/**
+ * Whether a drawImage() call from sourceWidth/Height into
+ * targetWidth/Height is actually resizing the image, as opposed to a ~1:1
+ * blit. Backs the imageSmoothingEnabled toggle in paint(): a rotated world
+ * still passes fractional (sub-pixel) coordinates into drawImage even at a
+ * clean 90deg angle, since the rotation pivot and destination x/y come
+ * from continuous pan/zoom/rotate math rather than integer device pixels.
+ * With smoothing always on, that sub-pixel misalignment gets bilinearly
+ * resampled and visibly softens tiles that are already at native
+ * resolution. Genuinely up/downscaled tiles still want smoothing to avoid
+ * a blocky look, so this only reports true once the size actually differs
+ * by more than a device-pixel's worth of rounding slop.
+ */
+export function needsSmoothing(
+  sourceWidth: number,
+  sourceHeight: number,
+  targetWidth: number,
+  targetHeight: number,
+  tolerance = 1
+): boolean {
+  return Math.abs(sourceWidth - targetWidth) > tolerance || Math.abs(sourceHeight - targetHeight) > tolerance;
+}
+
 export class CanvasRenderer implements Renderer {
+  /**
+   * Optional debug hook, set by tests/tooling, fired whenever a loaded tile
+   * image is drawn into its target canvas (schedulePaintToCanvas). Exists
+   * to make image-server aspect-ratio mismatches detectable: drawImage()
+   * here always stretches the loaded image to exactly fill the tile's
+   * target dimensions (computed from paint.display.points), with no check
+   * that the image actually loaded at a compatible aspect ratio -- if an
+   * image server returns something with a meaningfully different aspect
+   * ratio than what was requested (wrong crop parameters, a
+   * misconfigured/non-conformant IIIF service, etc.), the tile silently
+   * renders visibly stretched or squashed. No-op unless a test/tool sets
+   * it.
+   */
+  static debugImageStretch: ((event: ImageStretchDebugEvent) => void) | undefined;
+
+  /**
+   * Optional debug hook, set by tests/tooling, fired at each stage of a
+   * tile's network fetch: 'requested' when the fetch actually starts,
+   * 'loaded' once the image has decoded, 'failed' once loadImage has
+   * given up for good. Exists to make stuck/failed tile loads visible --
+   * normally a failed or endlessly-pending fetch has no on-screen signal
+   * at all, it just leaves whatever lower-resolution tile was already
+   * drawn there in place indefinitely. No-op unless a test/tool sets it.
+   */
+  static debugTileLoad: ((event: TileLoadDebugEvent) => void) | undefined;
+
   /**
    * The primary viewing space for the viewer.
    */
@@ -445,16 +573,26 @@ export class CanvasRenderer implements Renderer {
     }
   }
 
-  applyTransform(paint: Paintable, x: number, y: number, width: number, height: number) {
+  applyTransform(paint: Paintable, x: number, y: number, width: number, height: number, cx?: number, cy?: number) {
     const owner = paint.__owner.value;
     if (owner && owner.rotation) {
       this.ctx.save();
-      const moveX = x + width / 2;
-      const moveY = y + height / 2;
-
-      this.ctx.translate(moveX, moveY);
-      this.ctx.rotate((owner.rotation * Math.PI) / 180);
-      this.ctx.translate(-moveX, -moveY);
+      // x,y are the top left point of the box, not the center of the viewport
+      const halfWidth = width / 2;
+      const halfHeight = height / 2;
+      const angle = (owner.rotation * Math.PI) / 180;
+      // cx/cy only sent in if there's a unique rotation point
+      if (cx == undefined || cy == undefined) {
+        const moveX = x + halfWidth;
+        const moveY = y + halfHeight;
+        this.ctx.translate(moveX, moveY);
+        this.ctx.rotate(angle);
+        this.ctx.translate(-moveX, -moveY);
+      } else {
+        this.ctx.translate(cx, cy);
+        this.ctx.rotate(angle);
+        this.ctx.translate(-cx, -cy);
+      }
       this.lastPaintedObject = owner;
     }
   }
@@ -1059,6 +1197,8 @@ export class CanvasRenderer implements Renderer {
               target[0] += translationDeltaX;
               target[1] += translationDeltaY;
 
+              this.ctx.imageSmoothingEnabled = needsSmoothing(source[2], source[3], target[2], target[3]);
+
               this.ctx.drawImage(
                 canvasToPaint,
                 source[0],
@@ -1072,13 +1212,27 @@ export class CanvasRenderer implements Renderer {
               );
             }
           } else {
+            const sourceWidth = paint.display.points[index * 5 + 3] - paint.display.points[index * 5 + 1];
+            const sourceHeight = paint.display.points[index * 5 + 4] - paint.display.points[index * 5 + 2];
+
+            // Tiles are pre-rendered into canvasToPaint at their own native
+            // resolution, so a draw here at ~1:1 (sourceWidth/Height ==
+            // width/height) needs no resampling. Left smoothed, a rotated
+            // world (translate/rotate pivot on sub-pixel screen
+            // coordinates, even at a clean 90deg) still lands every source
+            // pixel off the destination grid, and bilinear filtering
+            // softens an already-native-resolution tile for no reason.
+            // Genuinely up/downscaled tiles still want smoothing to avoid
+            // a blocky look, so only skip it when the draw is ~1:1.
+            this.ctx.imageSmoothingEnabled = needsSmoothing(sourceWidth, sourceHeight, width, height);
+
             if (isFirefox) {
               this.ctx.drawImage(
                 canvasToPaint,
-                0,
-                0,
-                paint.display.points[index * 5 + 3] - paint.display.points[index * 5 + 1],
-                paint.display.points[index * 5 + 4] - paint.display.points[index * 5 + 2],
+                0, // paint.display.points[index * 5 + 1],
+                0, // paint.display.points[index * 5 + 2],
+                sourceWidth,
+                sourceHeight,
                 x,
                 y,
                 width + 1,
@@ -1087,10 +1241,10 @@ export class CanvasRenderer implements Renderer {
             } else {
               this.ctx.drawImage(
                 canvasToPaint,
-                0,
-                0,
-                paint.display.points[index * 5 + 3] - paint.display.points[index * 5 + 1],
-                paint.display.points[index * 5 + 4] - paint.display.points[index * 5 + 2],
+                0, // paint.display.points[index * 5 + 1],
+                0, // paint.display.points[index * 5 + 2],
+                sourceWidth,
+                sourceHeight,
                 x,
                 y,
                 width + Number.MIN_VALUE + 0.5,
@@ -1291,6 +1445,10 @@ export class CanvasRenderer implements Renderer {
           error: undefined,
         });
 
+        if (CanvasRenderer.debugTileLoad) {
+          CanvasRenderer.debugTileLoad({ paintId: paint.id, index, scale: paint.display.scale, url, status: 'requested' });
+        }
+
         try {
           const consumerId = `${tileKey}::${requestKey}`;
           const acquired = this.imageRequestPool.acquire(url, consumerId);
@@ -1340,6 +1498,23 @@ export class CanvasRenderer implements Renderer {
                     resolve();
                     return;
                   }
+                  if (CanvasRenderer.debugImageStretch) {
+                    const targetWidth = points[3] - points[1];
+                    const targetHeight = points[4] - points[2];
+                    CanvasRenderer.debugImageStretch({
+                      url,
+                      naturalWidth: image.naturalWidth,
+                      naturalHeight: image.naturalHeight,
+                      targetWidth,
+                      targetHeight,
+                      x: points[1],
+                      y: points[2],
+                      paintId: paint.id,
+                      index,
+                      stretched: isImageStretched(image.naturalWidth, image.naturalHeight, targetWidth, targetHeight),
+                      isVisible: this.visible.indexOf(paint) !== -1,
+                    });
+                  }
                   ctx.drawImage(image, 0, 0, points[3] - points[1], points[4] - points[2]);
                   const finalState = this.getTileState(imageBuffer, index);
                   this.setTileState(imageBuffer, index, {
@@ -1352,6 +1527,9 @@ export class CanvasRenderer implements Renderer {
                   });
                   this.enqueueTileReveal(tileKey, imageBuffer, index);
                   this.imagesLoaded++;
+                  if (CanvasRenderer.debugTileLoad) {
+                    CanvasRenderer.debugTileLoad({ paintId: paint.id, index, scale: paint.display.scale, url, status: 'loaded' });
+                  }
                   resolve();
                 });
               }),
@@ -1391,6 +1569,10 @@ export class CanvasRenderer implements Renderer {
           });
           this.pendingTileReveals.delete(tileKey);
 
+          if (!willRetry && CanvasRenderer.debugTileLoad) {
+            CanvasRenderer.debugTileLoad({ paintId: paint.id, index, scale: paint.display.scale, url, status: 'failed' });
+          }
+
           this.emitImageError({
             severity: 'recoverable',
             imageUrl: url,
@@ -1407,28 +1589,15 @@ export class CanvasRenderer implements Renderer {
     });
     return true;
   }
-
   afterPaintLayer(paint: SpacialContent, transform: Strand): void {
     // No-op
   }
 
-  prepareLayer(paint: SpacialContent, points: Strand): void {
+  prepareLayer(paint: SpacialContent, points: Strand, cx?: number, cy?: number): void {
     this.hasActiveLayerClip = false;
 
     if (paint.__owner.value) {
-      if (paint.cropData) {
-        const scale = this.lastKnownScale * (1 / paint.display.scale);
-        this.applyTransform(paint, points[1], points[2], points[3] - points[1], points[4] - points[2]);
-        // this.applyTransform(
-        //   paint,
-        //   points[1] - paint.cropData.x * scale + paint.points[1] * scale,
-        //   points[2] - paint.cropData.y * scale + paint.points[2] * scale,
-        //   paint.cropData.width * this.lastKnownScale,
-        //   paint.cropData.height * this.lastKnownScale
-        // );
-      } else {
-        this.applyTransform(paint, points[1], points[2], points[3] - points[1], points[4] - points[2]);
-      }
+      this.applyTransform(paint, points[1], points[2], points[3] - points[1], points[4] - points[2], cx, cy);
     }
 
     if (this.shouldClipLayerToBounds(paint)) {

--- a/src/modules/composite-renderer/composite-renderer.ts
+++ b/src/modules/composite-renderer/composite-renderer.ts
@@ -86,9 +86,9 @@ export class CompositeRenderer implements Renderer {
     return false;
   }
 
-  prepareLayer(paint: SpacialContent, point: Strand): void {
+  prepareLayer(paint: SpacialContent, point: Strand, cx?: number, cy?:number): void {
     for (let i = 0; i < this.length; i++) {
-      this.renderers[i].prepareLayer(paint, point);
+      this.renderers[i].prepareLayer(paint, point, cx, cy);
     }
   }
 

--- a/src/modules/overlay-renderer/overlay-renderer.ts
+++ b/src/modules/overlay-renderer/overlay-renderer.ts
@@ -72,15 +72,32 @@ export class OverlayRenderer implements Renderer {
     this.stylesheet.updateSheet();
   }
 
+  /**
+   * Whether this paint should get an HTML overlay host at all -- must stay
+   * in sync with what paint() below treats as "has a host" (it reads
+   * paint.__host.tx unconditionally once this is true), since createHtmlHost
+   * is the only thing that ever sets __host. They used to be two separately
+   * written conditions that quietly drifted apart: this one didn't check
+   * options.text, so a plain <paragraph>/Text with none of
+   * className/html/href never got __host created, and paint() then threw
+   * reading .tx off it. Sharing one method removes that failure mode.
+   *
+   * Must include paint.props.href in the Box branch: createHtmlHost below
+   * still special-cases href to build an <a> host even with no
+   * className/html/options.box, and that host is what HTMLPortal.tsx's
+   * box.__onCreate hook needs to ever fire for an href-only box. Dropping
+   * it here once made that condition inconsistent with createHtmlHost's own
+   * -- exactly the drift this method exists to prevent.
+   */
+  private shouldHostPaint(paint: SpacialContent): paint is Text | Box {
+    return (
+      (this.options.text && paint instanceof Text) ||
+      (paint instanceof Box && !!(this.options.box || paint.props.className || paint.props.html || paint.props.href))
+    );
+  }
+
   createHtmlHost(paint: Text | Box) {
-    if (
-      this.htmlContainer &&
-      ((paint instanceof Text && this.options.text) ||
-        this.options.box ||
-        paint.props.className ||
-        paint.props.html ||
-        paint.props.href)
-    ) {
+    if (this.htmlContainer && this.shouldHostPaint(paint)) {
       const div = document.createElement(paint.props.href ? 'a' : 'div');
       if (paint.props.href) {
         div.style.display = 'block';
@@ -267,12 +284,14 @@ export class OverlayRenderer implements Renderer {
   paint(paint: SpacialContent, index: number, x: number, y: number, width: number, height: number): void {
     this.zIndex++;
 
-    if (
-      ((this.options.text && paint instanceof Text) ||
-        (paint instanceof Box && (this.options.box || paint.props.className || paint.props.html))) &&
-      paint.__host &&
-      paint.__host.tx !== this.paintTx
-    ) {
+    // shouldHostPaint's own comment covers why this can no longer diverge
+    // from createHtmlHost's condition -- paint.__host is only ever set
+    // there, so this branch is never taken without a host having already
+    // been created. The paint.__host truthiness check is kept anyway
+    // (main's own independent defense against the same class of crash) as
+    // a cheap extra guard against any other host-creation path this
+    // condition doesn't know about.
+    if (this.shouldHostPaint(paint) && paint.__host && paint.__host.tx !== this.paintTx) {
       this.visible.push(paint);
       paint.__host.tx = this.paintTx;
 

--- a/src/modules/popmotion-controller/popmotion-controller.ts
+++ b/src/modules/popmotion-controller/popmotion-controller.ts
@@ -181,6 +181,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         momentum.active = false;
         momentum.vx = 0;
         momentum.vy = 0;
+        runtime.panMomentumActive = false;
       }
 
       function clearGestureState() {
@@ -358,6 +359,25 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         });
       }
 
+      // Total screen-px travel across the whole press, from the first pan
+      // sample (recorded at mousedown) to the last -- distinct from
+      // state.hasMovedSincePress, which flips true on *any* mousemove that
+      // nudges `nextTarget` by even a fraction of a world unit. Real pointer
+      // input is never perfectly still between mousedown and mouseup (a click
+      // routinely delivers a mousemove or two of a pixel or so of jitter), so
+      // hasMovedSincePress is true for nearly every click, not just real
+      // drags -- unusable as a "was this actually a pan" signal. This reuses
+      // calculateReleaseVelocity's own MIN_MOMENTUM_TRAVEL_PX noise floor
+      // instead.
+      function releaseTravelPx() {
+        if (panSamples.length < 2) {
+          return 0;
+        }
+        const first = panSamples[0];
+        const last = panSamples[panSamples.length - 1];
+        return Math.hypot(last.x - first.x, last.y - first.y) * runtime.getScaleFactor();
+      }
+
       function calculateReleaseVelocity() {
         if (panSamples.length < 2) {
           return null;
@@ -409,6 +429,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
           return false;
         }
         momentum.active = true;
+        runtime.panMomentumActive = true;
         momentum.vx = vx;
         momentum.vy = vy;
         runtime.updateNextFrame();
@@ -425,7 +446,18 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
           return;
         }
         const startedMomentum = runtime.mode === 'explore' ? maybeStartPanMomentum() : false;
-        if (runtime.mode === 'explore' && !startedMomentum) {
+        // Only correct out-of-bounds position on release if the pointer
+        // actually panned by more than noise (releaseTravelPx, not the far
+        // more sensitive state.hasMovedSincePress -- see that function's own
+        // comment for why). A plain click/tap never moves `target` itself,
+        // so it has nothing of its own to correct -- but without this guard,
+        // a click that happens to land while inertial momentum is still
+        // carrying the view through its elastic overshoot (stopped dead by
+        // onMouseDown's stopPanMomentum, *before* it had settled back within
+        // bounds on its own) would unconditionally kick off a fresh,
+        // click-triggered 500ms constrain-bounds snap -- visibly moving the
+        // view as a side effect of a click that never dragged anything.
+        if (runtime.mode === 'explore' && !startedMomentum && releaseTravelPx() >= MIN_MOMENTUM_TRAVEL_PX) {
           runtime.world.constraintBounds();
         }
         state.isPressing = false;

--- a/src/modules/popmotion-controller/popmotion-controller.ts
+++ b/src/modules/popmotion-controller/popmotion-controller.ts
@@ -433,6 +433,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         clearPanSamples();
         clearGestureState();
         resetState();
+        runtime.endInteraction();
       }
 
       function releaseGesturePointer() {
@@ -463,6 +464,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         clearPanSamples();
         clearGestureState();
         resetState();
+        runtime.endInteraction();
       }
 
       runtime.world.activatedEvents.push(
@@ -521,6 +523,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
         if (e.which > 1) {
           resetHoldToHomeState();
           state.isPressing = false;
+          runtime.endInteraction();
           return;
         }
         if (runtime.mode === 'explore') {
@@ -536,6 +539,10 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
 
           state.isPressing = true;
           armHoldToHome(typeof e.clientX === 'number' ? e.clientX : 0, typeof e.clientY === 'number' ? e.clientY : 0);
+          // Matches onTouchStart's own unconditional call below --
+          // Runtime#beginInteraction is itself a no-op when a gesture is
+          // already in progress, so this doesn't need its own guard here.
+          runtime.beginInteraction();
         }
       }
 
@@ -592,6 +599,7 @@ export const popmotionController = (config: PopmotionControllerConfig = {}): Run
           runtime.transitionManager.stopTransition();
 
           state.isPressing = true;
+          runtime.beginInteraction();
         }
       }
 

--- a/src/modules/react-reconciler/Atlas.tsx
+++ b/src/modules/react-reconciler/Atlas.tsx
@@ -103,6 +103,7 @@ export type AtlasProps = {
   devTools?: boolean | DevToolsProps;
   runtimeOptions?: Partial<RuntimeOptions>;
   filters?: Partial<ViewerFilters>;
+  rotateFromWorldCenter?: boolean;
 };
 
 const filterProperties = [
@@ -159,6 +160,7 @@ export const Atlas: React.FC<
     filters,
     homePaddingPx,
     devTools,
+    rotateFromWorldCenter = false,
     ...restProps
   } = props;
 
@@ -536,6 +538,14 @@ export const Atlas: React.FC<
       }
     }
   }, [preset, restProps.width, restProps.height, viewport]);
+
+  useEffect(() => {
+    if (preset) {
+      const rt: Runtime = preset.runtime;
+
+      rt.rotateFromWorldCenter = rotateFromWorldCenter;
+    }
+  }, [preset, rotateFromWorldCenter])
 
   useEffect(() => {
     if (filters && preset) {

--- a/src/modules/react-reconciler/components/AtlasAuto.tsx
+++ b/src/modules/react-reconciler/components/AtlasAuto.tsx
@@ -17,7 +17,7 @@ export const AtlasAuto: React.FC<
   const autoId = useId();
   const { className: containerPropsClassName, ...restContainerProps } = containerProps;
 
-  const { height, width, ...restProps } = props as any;
+  const { height, width, rotateFromWorldCenter, ...restProps } = props as any;
 
   useEffect(() => {
     forceRefresh();
@@ -53,7 +53,7 @@ export const AtlasAuto: React.FC<
   return (
     <Container ref={ref} {...restContainerProps} className={combinedClassName}>
       {bounds.width ? (
-        <Atlas width={bounds.width || 100} height={bounds.height || 100} {...restProps}>
+        <Atlas width={bounds.width || 100} height={bounds.height || 100} rotateFromWorldCenter={rotateFromWorldCenter} {...restProps}>
           {props.children}
         </Atlas>
       ) : null}

--- a/src/modules/react-reconciler/components/ImageService.tsx
+++ b/src/modules/react-reconciler/components/ImageService.tsx
@@ -27,7 +27,13 @@ export const ImageService: React.FC<{
   }, [props.height, props.id, props.width]);
 
   return (
-    <world-object x={props.x || 0} y={props.y || 0} width={props.width} height={props.height} scale={props.scale}>
+    <world-object
+      x={props.x || 0}
+      y={props.y || 0}
+      width={props.crop?.width || props.width}
+      height={props.crop?.height || props.height}
+      scale={props.scale}
+    >
       {tiles ? (
         <TileSet
           tiles={tiles}

--- a/src/modules/react-reconciler/hooks/use-diff-props.ts
+++ b/src/modules/react-reconciler/hooks/use-diff-props.ts
@@ -35,7 +35,6 @@ function diffProps(
 export function useDiffProps(props: any, name = '', enabled = false) {
   const prevProps = useRef(props);
   if (prevProps.current && enabled) {
-    console.log('Diff:', name, diffProps(prevProps.current, props));
     prevProps.current = props;
   }
 }

--- a/src/modules/react-reconciler/hooks/use-preset.ts
+++ b/src/modules/react-reconciler/hooks/use-preset.ts
@@ -2,6 +2,7 @@ import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { type PresetNames, type Presets, presets } from '../presets';
 import type { Preset, PresetArgs } from '../presets/_types';
 import { defaultPreset } from '../presets/default-preset';
+import { deferToMicrotask } from '../../../utility/defer-to-microtask';
 
 const defaultArgs = {};
 
@@ -94,9 +95,19 @@ export function usePreset(
       ...(presetArgs || {}),
     });
 
-    setPreset(createdPreset);
+    // React StrictMode (dev only) synchronously double-invokes this effect on
+    // mount: mount -> cleanup -> mount again, all before any microtask runs.
+    // Exposing `createdPreset` via setPreset() immediately would let the
+    // *first* (about-to-be-destroyed) preset flow downstream and spawn its
+    // own reconciler tree / fire onCreated, racing the real, surviving
+    // instance from the second invocation. Deferring past a microtask lets
+    // the synchronous double-invoke finish first, so a preset torn down by
+    // its own cleanup is never published to the rest of the tree. See
+    // deferToMicrotask's own tests for the defer/cancel logic in isolation.
+    const cancelDeferredSetPreset = deferToMicrotask(() => setPreset(createdPreset));
 
     return () => {
+      cancelDeferredSetPreset();
       if (createdPreset) {
         const currentViewport = createdPreset.runtime.getViewport();
         viewport.current = {

--- a/src/modules/react-reconciler/reconciler.ts
+++ b/src/modules/react-reconciler/reconciler.ts
@@ -475,7 +475,6 @@ const reconciler = Reconciler
 
       detachDeletedInstance(node) {
         // no-op?
-        // console.log('detachDeletedInstance', node);
       },
 
       afterActiveInstanceBlur() {

--- a/src/modules/react-reconciler/reconciler.ts
+++ b/src/modules/react-reconciler/reconciler.ts
@@ -560,8 +560,11 @@ const reconciler = Reconciler
   : null;
 
 if (reconciler) {
-  // @ts-expect-error DefinitelyTyped is not up to date
-  reconciler.injectIntoDevTools();
+  reconciler.injectIntoDevTools({
+    bundleType: process.env.NODE_ENV === 'production' ? 0 : 1,
+    rendererPackageName: '@atlas-viewer/atlas',
+    version,
+  });
 }
 
 export function unmountComponentAtNode(runtime: Runtime, callback?: (runtime: any) => void) {

--- a/src/modules/react-reconciler/types.ts
+++ b/src/modules/react-reconciler/types.ts
@@ -28,6 +28,7 @@ declare global {
         width?: number;
         height?: number;
         children?: React.ReactNode;
+        rotateFromWorldCenter?: boolean;
       } & AllEvents;
       worldObject: BaseElement & {
         children?: React.ReactNode;

--- a/src/modules/transition-manager/transition-manager.ts
+++ b/src/modules/transition-manager/transition-manager.ts
@@ -58,7 +58,18 @@ export class TransitionManager {
   runTransition(target: Strand, delta: number) {
     if (!this.pendingTransition.done) {
       const transition = this.pendingTransition;
-      const td = transition.total_time === 0 ? 0 : (transition.elapsed_time + delta) / transition.total_time;
+      // Clamped to 1: an unusually large single-frame delta (a backgrounded
+      // tab resuming, a dropped frame, a GC pause) can otherwise push td
+      // past 1, and easing functions like easeOutQuart (1 - (1-x)^4) are
+      // only monotonic on [0, 1] -- past that they curve back down instead
+      // of staying at the endpoint, so `step` collapses toward 0 right when
+      // elapsed_time >= total_time marks the transition done. That leaves
+      // `target` stuck wherever that bad step landed it, permanently (since
+      // nothing else re-triggers a correction), for example a
+      // constrain-bounds snap-back that reports done but never actually
+      // arrives back in bounds.
+      const rawTd = transition.total_time === 0 ? 0 : (transition.elapsed_time + delta) / transition.total_time;
+      const td = rawTd > 1 ? 1 : rawTd;
       const step = transition.total_time === 0 ? 1 : td === 0 ? 0 : transition.timingFunction(td);
 
       // Update our target.
@@ -156,7 +167,6 @@ export class TransitionManager {
   } = {}) {
     this.isConstraining = true;
     const [isConstrained, constrained] = this.runtime.constrainBounds(this.runtime.target, { panPadding });
-
     if (isConstrained) {
       this.applyTransition(constrained, transition, {
         duration: 500,
@@ -167,6 +177,12 @@ export class TransitionManager {
         }
       });
       this.runtime.updateNextFrame();
+      // Main independently fixed the same "isConstraining stuck true
+      // forever" bug touch-old fixed (nothing else clears it when there
+      // was no correction to make, since the trailing reset below used to
+      // run unconditionally even after this branch already started a
+      // correction) -- this early return already covers it, so touch-old's
+      // more verbose explicit else-branch version isn't needed on top.
       return;
     }
 

--- a/src/objects/base-object.ts
+++ b/src/objects/base-object.ts
@@ -122,6 +122,24 @@ export abstract class BaseObject<Props = any, SupportedChildElements = never>
     mutate(this.points, translate(x, y));
   }
 
+  /**
+   * Some subclasses' applyProps() sets points directly from x/y-ish props on
+   * every call, which the reconciler invokes on every re-render regardless
+   * of whether those props actually changed (see reconciler.ts prepareUpdate,
+   * which never diffs old vs new props). A plain translate() would then get
+   * silently wiped out the next time any unrelated prop changes trigger a
+   * re-render. Runtime#compensateRotationPivotChange uses this instead so
+   * the compensating offset is remembered and reapplied by those subclasses'
+   * applyProps() on top of whatever position the props currently declare.
+   */
+  pivotCompensationOffset = { x: 0, y: 0 };
+
+  applyPivotCompensationOffset(x: number, y: number) {
+    this.pivotCompensationOffset.x += x;
+    this.pivotCompensationOffset.y += y;
+    this.translate(x, y);
+  }
+
   atScale(factor: number) {
     mutate(this.points, scaleAtOrigin(factor, this.x, this.y));
     this.scale *= factor;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -10,7 +10,7 @@ export interface Renderer {
   paint(paint: SpacialContent, index: number, x: number, y: number, width: number, height: number): void;
   afterFrame(world: World, delta: number, target: Strand, options: HookOptions): void;
   getScale(width: number, height: number, dpi?: boolean): number;
-  prepareLayer(paint: SpacialContent, point: Strand): void;
+  prepareLayer(paint: SpacialContent, point: Strand, cx?: number, cy?:number): void;
   finishLayer(paint: SpacialContent, point: Strand): void;
   afterPaintLayer(paint: SpacialContent, transform?: Strand): void;
   pendingUpdate(): boolean;

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -19,6 +19,7 @@ import { getZoneConstrainedBounds } from '../utility/get-zone-constrained-bounds
 import type { World } from '../world';
 import type { Paint } from '../world-objects/paint';
 import type { Renderer } from './renderer';
+import { rotatePoint } from '../world-objects/world-object';
 
 export type RuntimeHooks = {
   useFrame: Array<(time: number) => void>;
@@ -70,6 +71,11 @@ export class Runtime {
   readyTimestamp: number | undefined;
   resourceTransitionKey: string | number | undefined;
   private hasResourceTransitionKey = false;
+
+  _rotateFromWorldCenter: boolean = false;
+  private hasSyncedRotateFromWorldCenter = false;
+  viewportCenterPoint: { x: number; y: number; } = { x: 0, y: 0 };
+  viewport: { x: number; y: number; width: number; height: number; top: number; left: number; } | undefined;
   // Helper getters.
   get x(): number {
     return this.target[1];
@@ -118,6 +124,528 @@ export class Runtime {
   set height(height: number) {
     this.target[4] = this.target[2] = height;
   }
+
+
+  get rotateFromWorldCenter(): boolean {
+    return this._rotateFromWorldCenter;
+  }
+
+  set rotateFromWorldCenter(rotateFromWorldCenter: boolean) {
+    if (rotateFromWorldCenter === this._rotateFromWorldCenter) {
+      // Still mark as synced even on a no-op assignment: AtlasAuto's effect
+      // that syncs this prop always fires on mount (see Atlas.tsx), and if
+      // the story's starting value happens to match this class's own false
+      // default, this early-return branch is the *only* place that first
+      // sync is ever observed. Without this, a story starting at false
+      // would never flip hasSyncedRotateFromWorldCenter here, making its
+      // user's first *real* toggle (false->true) get misidentified as the
+      // initial sync below and incorrectly skip compensation.
+      this.hasSyncedRotateFromWorldCenter = true;
+      return;
+    }
+    // AtlasAuto syncs this prop via a useEffect that always fires on mount
+    // (see Atlas.tsx), so the very first sync of e.g.
+    // <AtlasAuto rotateFromWorldCenter /> (starting true) looks like a
+    // false->true transition here purely because of this class's own
+    // false default -- not because anything was actually switched. There's
+    // no previously-rendered appearance under the old pivot mode to
+    // preserve in that case, so compensating would corrupt the initial
+    // position instead of protecting it. Only compensate for genuine,
+    // later toggles, once the mode has been synced at least once.
+    if (this.hasSyncedRotateFromWorldCenter) {
+      this.compensateRotationPivotChange(rotateFromWorldCenter);
+    }
+    this.hasSyncedRotateFromWorldCenter = true;
+    this._rotateFromWorldCenter = rotateFromWorldCenter;
+    if (!rotateFromWorldCenter) {
+      this.fixedWorldPivot = undefined;
+      this.pivotSwitchPending = false;
+    }
+    this.updateWorldObjectRotationPivots(this.currentWorldPivot());
+  }
+
+  /**
+   * The rotation-pivot gesture lifecycle: 'idle' the rest of the time,
+   * 'interacting' for the duration of a raw pointer gesture
+   * (mousedown/touchstart through mouseup/touchend), then 'switching' from
+   * the moment that gesture ends until the pivot has actually finished
+   * switching back from frozen to live (see endInteraction and
+   * finalizePivotSwitch -- that switch sometimes can't happen the instant
+   * the gesture ends, hence a distinct third state rather than treating
+   * "just ended" and "fully idle" as the same thing).
+   *
+   * isInteracting and pivotSwitchPending below are thin accessors over this
+   * single field, kept only because they're each read/written from several
+   * places (including tests) as independent booleans. They used to *be*
+   * two independent boolean fields -- every one of their own read sites
+   * needed both together (`isInteracting || pivotSwitchPending`, twice, see
+   * currentWorldPivot and compensateRotationPivotChange) precisely because
+   * they were never meant to vary independently: exactly one of the three
+   * states is ever true at a time. Modeling that directly here means a
+   * future edit to either accessor can't leave the pair in a combination
+   * that was never supposed to exist.
+   */
+  private pivotPhase: 'idle' | 'interacting' | 'switching' = 'idle';
+
+  /**
+   * True while a raw pointer gesture (mousedown/touchstart through
+   * mouseup/touchend) is actively in progress. Set only via
+   * beginInteraction()/endInteraction() -- see those for why.
+   */
+  get isInteracting(): boolean {
+    return this.pivotPhase === 'interacting';
+  }
+  set isInteracting(value: boolean) {
+    this.pivotPhase = value ? 'interacting' : 'idle';
+  }
+
+  /**
+   * The world-space point every rotated object's rotationPivot is derived
+   * from while rotateFromWorldCenter is on and a gesture (see
+   * isInteracting) -- or the post-gesture snap-back covered by
+   * pivotSwitchPending -- is in progress. Frozen for the duration of both
+   * -- see currentWorldPivot's doc comment for why.
+   */
+  private fixedWorldPivot: { x: number; y: number } | undefined;
+
+  /**
+   * True from the moment a gesture ends until the pivot has actually
+   * finished switching from frozen back to live -- see endInteraction and
+   * finalizePivotSwitch. Kept separate from isInteracting (which tracks
+   * only the raw pointer gesture) because that switch sometimes can't
+   * happen the instant the gesture ends: see finalizePivotSwitch's own
+   * comment for why.
+   */
+  private get pivotSwitchPending(): boolean {
+    return this.pivotPhase === 'switching';
+  }
+  private set pivotSwitchPending(value: boolean) {
+    if (value) {
+      this.pivotPhase = 'switching';
+    } else if (this.pivotPhase === 'switching') {
+      // Every false-write site (beginInteraction, finalizePivotSwitch, the
+      // rotateFromWorldCenter setter) is clearing this defensively rather
+      // than asserting the gesture itself just ended -- a call arriving
+      // while the phase is 'interacting' (e.g. rotateFromWorldCenter
+      // toggled off mid-drag) must leave that phase alone, not force it
+      // back to 'idle' out from under an active gesture.
+      this.pivotPhase = 'idle';
+    }
+  }
+
+  /**
+   * Called by whichever pan/zoom controller is attached (see
+   * PopmotionController's onMouseDown/onTouchStart) at the exact moment a
+   * raw pointer gesture starts, *before* that controller queues any
+   * movement.
+   *
+   * This must run synchronously here, rather than being inferred lazily
+   * from the next render() frame (which is how this was first implemented):
+   * PopmotionController issues each drag step as a zero-duration transition
+   * (total_time = 0), which render() applies to `target` *before* it gets a
+   * chance to notice isInteracting just turned true (both happen inside the
+   * same render() call, target-apply first). Deferring the pivot capture to
+   * that render() call would therefore capture it one step too late --
+   * *after* the first movement of the gesture has already shifted `target`
+   * -- corrupting exactly that first step (and only that step; every step
+   * after tracks correctly since the pivot is by then genuinely frozen).
+   * Capturing here, before the controller has touched `target` at all,
+   * avoids the race entirely.
+   *
+   * A no-op when a gesture is already in progress: PopmotionController
+   * calls this once per raw pointer/touch *start* event, and a second
+   * finger touching down mid-drag fires its own touchstart (with both
+   * touches now present) while the first finger's gesture is still active
+   * -- without this guard, that re-entrant call would re-capture
+   * fixedWorldPivot at whatever the live pivot has drifted to by that
+   * moment (instead of the position it was frozen at when the gesture
+   * actually began), producing a visible jump right as a one-finger pan
+   * transitions into a two-finger pinch/rotate.
+   */
+  beginInteraction() {
+    if (this.isInteracting) {
+      return;
+    }
+    this.isInteracting = true;
+    // A previous gesture's pivot switch may still be waiting on its own
+    // out-of-bounds snap-back to settle (see finalizePivotSwitch) -- this
+    // new gesture supersedes it entirely: fixedWorldPivot is about to be
+    // recaptured fresh below, so there's nothing left for that pending
+    // switch to finalize.
+    this.pivotSwitchPending = false;
+    if (this._rotateFromWorldCenter) {
+      // No compensation needed here: this freezes the pivot at whatever the
+      // live pivot is *right now*, so their screen projections coincide by
+      // construction -- nothing has had a chance to drift yet.
+      this.fixedWorldPivot = this.liveWorldPivot();
+    }
+  }
+
+  /**
+   * Pairs with beginInteraction() -- called when the gesture ends.
+   *
+   * Doesn't finalize the pivot switch itself; just marks it pending, for
+   * render() to finish (see finalizePivotSwitch) once it's actually safe
+   * to. onWindowMouseUp calls world.constraintBounds() immediately before
+   * this method, when the gesture ends out of bounds -- if that's about to
+   * animate `target` back into bounds, switching the pivot straight to live
+   * right now (even with a one-time compensating offset) can't stay
+   * consistent with several more frames of `target` still moving after this
+   * call returns. Keeping the pivot frozen for that entire snap-back, the
+   * same way it's already frozen for the gesture itself, sidesteps the
+   * inconsistency completely -- see finalizePivotSwitch.
+   */
+  endInteraction() {
+    this.isInteracting = false;
+    if (this._rotateFromWorldCenter && this.fixedWorldPivot) {
+      this.pivotSwitchPending = true;
+    } else {
+      this.fixedWorldPivot = undefined;
+    }
+  }
+
+  /**
+   * Finishes the frozen-to-live pivot switch that endInteraction() defers:
+   * compensates every rotated object so the switch itself doesn't move
+   * anything on screen (see syncRotationPivotPosition), then releases the
+   * frozen pivot.
+   *
+   * Called from render(), *before* getPointsAt() captures this frame's
+   * object positions for painting -- not from endInteraction() itself,
+   * and not from the rotateFromWorldCenter block further down in render()
+   * that reads the now-live pivot. Both would be too late: this method
+   * mutates each rotated object's own position (via
+   * syncRotationPivotPosition -> applyPivotCompensationOffset), and
+   * getAllPointsAt bakes each object's *current* x/y into that frame's
+   * transform up front -- a mutation applied after getPointsAt has already
+   * run for this frame wouldn't be reflected until the *next* one, so the
+   * frame in between would render the pre-compensation position under the
+   * already-switched (live) pivot: exactly the jump this exists to avoid,
+   * just delayed a frame instead of prevented.
+   *
+   * Only ever runs once pivotSwitchPending's own snap-back (if any) has
+   * actually finished animating `target` -- render() only calls this once
+   * transitionManager.hasPending() has gone false again, so `target` here
+   * is always genuinely settled, not a value this method has to guess or
+   * borrow from anywhere else.
+   *
+   * A previous version of this compensation skipped it entirely, reasoning
+   * that image content (TiledImage/SingleImage) renders its own rotation
+   * around its own center only and never reads the external cx/cy pivot --
+   * unlike Box/Text, painted through CanvasRenderer#applyTransform, which
+   * does. That's not what CanvasRenderer#prepareLayer/#applyTransform
+   * actually do: applyTransform is invoked for every paint (any
+   * SpacialContent, not just Box/Text) and branches purely on
+   * `owner.rotation` -- the *world-object's* rotation, not the paint's own
+   * -- so a TiledImage/SingleImage inside a rotated world-object is
+   * rotated around the external pivot exactly like Box/Text is. Skipping
+   * compensation left that case with no correction at all, reintroducing
+   * the jump this method exists to avoid (confirmed against
+   * runtime-interaction-pivot.test.ts's own compensation math).
+   */
+  private finalizePivotSwitch() {
+    if (this.fixedWorldPivot) {
+      const oldPivotScreen = this.projectToScreen(this.fixedWorldPivot);
+      this.viewport = this.getRendererScreenPosition();
+      this.updateViewportCenterPoint();
+      this.syncRotationPivotPosition(oldPivotScreen, this.viewportCenterPoint);
+    }
+    this.fixedWorldPivot = undefined;
+    this.pivotSwitchPending = false;
+  }
+
+  /** The live world point currently at the viewport's screen center. */
+  private liveWorldPivot(): { x: number; y: number } {
+    return this.viewerToWorld(this.viewportCenterPoint.x, this.viewportCenterPoint.y);
+  }
+
+  /** Screen-space projection of a world-space pivot, for the *current* target/scale. */
+  private projectToScreen(worldPivot: { x: number; y: number }): { x: number; y: number } {
+    const p = this.worldToViewer(worldPivot.x, worldPivot.y, 0, 0);
+    return { x: p.x, y: p.y };
+  }
+
+  /**
+   * Nudges every rotated world-object's position so that switching the
+   * render pivot it's drawn around from `oldPivot` to `newPivot` doesn't
+   * move anything on screen: whatever is visible right now stays exactly
+   * where it is, and only a *future* rotation change (or another pivot
+   * switch) will actually sweep around the new pivot.
+   *
+   * Either side may be a fixed screen coordinate, or the literal string
+   * 'own-center' -- meaning "this object's own current screen position",
+   * i.e. own-center rotation mode, where the pivot moves *with* the object
+   * rather than being fixed. That's not just a convenience: an own-center
+   * pivot isn't expressible as a plain {x,y}, since it's whatever the
+   * object's post-compensation position turns out to be -- solving for a
+   * fixed pivot's inverse rotation doesn't apply.
+   *
+   * Walks the whole tree, not just this.world.getObjects()'s top-level
+   * nodes -- e.g. ImageService renders its rotation onto TileSet's own
+   * *nested* world-object wrapper (see TileSet.tsx), not the top-level one
+   * ImageService itself creates. updateWorldObjectRotationPivots already
+   * has to recurse into .layers for exactly this reason (its own doc
+   * comment covers it); this didn't, so a rotated node at any depth below
+   * the top level never got its position compensated at all, reintroducing
+   * the on-release jump this method exists to avoid for any story that
+   * rotates through a nested wrapper instead of a top-level one.
+   */
+  private syncRotationPivotPosition(
+    oldPivot: { x: number; y: number } | 'own-center',
+    newPivot: { x: number; y: number } | 'own-center'
+  ) {
+    const scaleFactor = this.getScaleFactor();
+
+    // oldParentX/Y and newParentX/Y both track the same ancestor chain's
+    // absolute position -- identical unless some ancestor between here and
+    // the root was itself rotated and so had its own compensation applied
+    // a level up. They diverge exactly when a rotated node sits inside
+    // another rotated node (e.g. ImageService applying its own rotation on
+    // a nested wrapper, itself inside a rotated <world-object> -- see
+    // TileSet.tsx): the outer node's compensation moves its own x/y, which
+    // ordinary translation composition then carries down to everything
+    // below it, rotated or not. A rotated *descendant*'s own compensation
+    // must be solved relative to where its ancestor chain will *actually*
+    // be once rendered (newParentX/Y) -- not where that chain was before
+    // this whole pass started (oldParentX/Y) -- or the descendant ends up
+    // silently absorbing its ancestor's own shift a second time on top of
+    // its own, correctly-computed one. A sibling with no rotation of its
+    // own (e.g. a <box> next to the rotated image) never runs this branch
+    // at all, so it only ever inherits the ancestor's shift once, via
+    // ordinary composition -- confirmed live against
+    // stories/rotation.stories.tsx's CropImageBroken (rotation set on both
+    // the <world-object> and the <ImageService> it contains): the image
+    // content, alone among that object's children, drifted away from the
+    // rest during every rotate-from-center drag. See
+    // runtime-interaction-pivot.test.ts for the regression coverage and
+    // the worked-through math.
+    const visit = (
+      nodes: any[],
+      oldParentX: number,
+      oldParentY: number,
+      newParentX: number,
+      newParentY: number,
+      parentScale: number
+    ) => {
+      for (const owner of nodes) {
+        if (!owner) {
+          continue;
+        }
+
+        const nodeScale = parentScale * (typeof owner.scale === 'number' ? owner.scale : 1);
+        // owner's own local x/y are untouched by any ancestor's shift --
+        // only owner's own compensation (below) can change them -- so this
+        // is valid both before and after that runs.
+        const oldAbsX = oldParentX + owner.x * parentScale;
+        const oldAbsY = oldParentY + owner.y * parentScale;
+
+        if (owner.rotation) {
+          const screen = this.worldToViewer(oldAbsX, oldAbsY, owner.width * parentScale, owner.height * parentScale);
+          const px = screen.x + screen.width / 2;
+          const py = screen.y + screen.height / 2;
+
+          // Where this object is actually rendered right now, under the old
+          // pivot. Own-center has no positional effect (the pivot moves with
+          // the object), so the rendered position is just its raw position.
+          // Uses the same rotatePoint() helper WorldObject#applyRotation
+          // does, rather than a second hand-written copy of the same
+          // formula -- this file and world-object.ts already once
+          // diverged this way (see rotate() vs rotatePoint() in
+          // world-object.ts), which is exactly the kind of drift reusing
+          // one shared implementation avoids.
+          let renderedX = px;
+          let renderedY = py;
+          if (oldPivot !== 'own-center') {
+            [renderedX, renderedY] = rotatePoint(px, py, oldPivot.x, oldPivot.y, owner.rotation);
+          }
+
+          // Solve for the raw (pre-rotation) position that would render at
+          // that same spot under the new pivot. Own-center is again
+          // trivial: it's whatever the rendered position already is, since
+          // own-center makes raw and rendered position identical by
+          // construction.
+          let newPx = renderedX;
+          let newPy = renderedY;
+          if (newPivot !== 'own-center') {
+            [newPx, newPy] = rotatePoint(renderedX, renderedY, newPivot.x, newPivot.y, -owner.rotation);
+          }
+
+          // (newPx - px)/scaleFactor is the raw world-space delta that
+          // would keep owner's own rendered appearance fixed *if its
+          // ancestor chain's absolute position stayed exactly where it was
+          // (oldParentX/Y)*. It generally won't have: subtracting the
+          // ancestor chain's own world-space shift (newParent - oldParent)
+          // before dividing down into owner's local frame accounts for
+          // whatever part of the needed correction owner's ancestors are
+          // already contributing via their own compensation, so owner only
+          // solves for what's left over that's genuinely its own -- see
+          // this method's own top-level comment for why that split
+          // matters. Reduces to the original (single-rotation-per-branch)
+          // formula whenever no ancestor had anything of its own to
+          // contribute, since newParentX/Y == oldParentX/Y in that case.
+          const worldDx = ((newPx - px) / scaleFactor - (newParentX - oldParentX)) / parentScale;
+          const worldDy = ((newPy - py) / scaleFactor - (newParentY - oldParentY)) / parentScale;
+
+          if (worldDx || worldDy) {
+            owner.applyPivotCompensationOffset(worldDx, worldDy);
+          }
+        }
+
+        if (Array.isArray(owner.layers) && owner.layers.length) {
+          // owner.x/y read fresh here -- reflects owner's own compensation
+          // above, if any ran, so newAbsX/Y is where owner will actually
+          // render, not where it started.
+          const newAbsX = newParentX + owner.x * parentScale;
+          const newAbsY = newParentY + owner.y * parentScale;
+          visit(owner.layers, oldAbsX, oldAbsY, newAbsX, newAbsY, nodeScale);
+        }
+      }
+    };
+
+    visit(this.world.getObjects(), 0, 0, 0, 0, 1);
+    this.pendingUpdate = true;
+  }
+
+  /**
+   * The world-space rotation pivot to use for this frame, or undefined if
+   * rotateFromWorldCenter is off.
+   *
+   * "Rotate from viewport center" is ambiguous during a pan: the render-time
+   * pivot (CanvasRenderer#applyTransform's cx/cy) is a screen coordinate,
+   * and panning shifts every object's raw screen position by a uniform
+   * delta *before* rotation is applied. If the pivot were pinned to the
+   * canvas's literal center pixel throughout, that delta gets rotated too --
+   * `R(rotation) * panDelta` instead of `panDelta` -- so a rotated object
+   * sweeps off in a rotated direction relative to the mouse instead of
+   * tracking the pan 1:1. But re-deriving the pivot from
+   * viewerToWorld(viewportCenterPoint) fresh every frame (so it's *always*
+   * the literal current center, with no sweep-avoidance) means the object
+   * genuinely does rotate around a moving target while you drag -- also not
+   * what "rotate from center" should feel like while dragging.
+   *
+   * The compromise: while idle (no gesture in progress), the pivot always
+   * tracks the live, true viewport center -- matching what a user expects
+   * "center of the viewport" to mean at rest, and self-correcting through
+   * any transient view changes (e.g. settling into its home position after
+   * mount) the same way it always did. The instant a gesture starts
+   * (beginInteraction), the world point is captured once and held fixed for
+   * its duration, so panning/zooming while it's running reads as a plain,
+   * uniform shift instead of sweeping rotated content around. Once it ends
+   * (endInteraction) tracking eventually resumes and the pivot snaps back
+   * to whatever the true center now is -- but not necessarily the instant
+   * it ends: see pivotSwitchPending/finalizePivotSwitch for why that switch
+   * can't always happen right away, and why by the time this method is
+   * called by render() (see finalizePivotSwitch's own comment on
+   * ordering), that switch -- if one was due -- has already happened.
+   */
+  private currentWorldPivot(): { x: number; y: number } | undefined {
+    if (!this._rotateFromWorldCenter) {
+      return undefined;
+    }
+    if (this.pivotPhase !== 'idle') {
+      // Normally captured by beginInteraction() already; this only covers
+      // the edge case of rotateFromWorldCenter being switched on mid-gesture,
+      // where there was nothing to capture yet when the gesture started.
+      this.fixedWorldPivot = this.fixedWorldPivot ?? this.liveWorldPivot();
+      return this.fixedWorldPivot;
+    }
+    return this.liveWorldPivot();
+  }
+
+  /**
+   * Keeps every world-object's `rotationPivot` in sync with the current
+   * world pivot (see currentWorldPivot), expressed in *each node's own*
+   * local coordinate frame (i.e. relative to its parent, at its parent's
+   * accumulated scale) rather than the top-level world frame.
+   *
+   * This must cover every rotated node at any nesting depth, not just
+   * top-level ones: CanvasRenderer passes the viewport-center pivot to
+   * *every* paint uniformly whenever rotateFromWorldCenter is on (see the
+   * unconditional `this.rotateFromWorldCenter ? this.viewportCenterPoint...`
+   * in render() below), regardless of which ancestor owns it -- e.g. an
+   * ImageService/TileSet's own nested rotated wrapper. WorldObject#applyProps
+   * (screen-aligned x/y) and WorldObject#applyRotation (visibility culling)
+   * both need a rotationPivot that matches whatever pivot the node is
+   * actually rendered with, or they'll disagree with the renderer -- at
+   * extreme scale/position this can make applyRotation cull a node that's
+   * actually on screen, hiding it entirely.
+   */
+  private updateWorldObjectRotationPivots(worldPivot: { x: number; y: number } | undefined) {
+    const setPivot = (nodes: any[], parentX: number, parentY: number, parentScale: number) => {
+      for (const node of nodes) {
+        if (!node) {
+          continue;
+        }
+        if (worldPivot) {
+          // Reuse the existing rotationPivot object (if this node already
+          // has one from a previous frame) instead of allocating a new one
+          // every frame for every node -- this runs on every render() call
+          // while rotateFromWorldCenter is on, including every frame of an
+          // active drag, so a fresh object per node here means real GC
+          // pressure exactly when frame time matters most. The three read
+          // sites (WorldObject#applyRotation/#applyProps,
+          // Runtime#compensateRotationPivotChange) all read .x/.y
+          // synchronously and never hold onto a rotationPivot reference
+          // across frames, so mutating in place is safe.
+          const px = (worldPivot.x - parentX) / parentScale;
+          const py = (worldPivot.y - parentY) / parentScale;
+          if (node.rotationPivot) {
+            node.rotationPivot.x = px;
+            node.rotationPivot.y = py;
+          } else {
+            node.rotationPivot = { x: px, y: py };
+          }
+        } else {
+          node.rotationPivot = undefined;
+        }
+
+        const absX = parentX + node.x * parentScale;
+        const absY = parentY + node.y * parentScale;
+        const nodeScale = parentScale * (typeof node.scale === 'number' ? node.scale : 1);
+        if (Array.isArray(node.layers) && node.layers.length) {
+          setPivot(node.layers, absX, absY, nodeScale);
+        }
+      }
+    };
+    setPivot(this.world.getObjects(), 0, 0, 1);
+  }
+
+  /**
+   * Switching the rotation pivot (own-center vs. viewport-center) for an object
+   * that already has a non-zero rotation would otherwise cause it to jump, since
+   * the same angle drawn around a different point lands the shape somewhere else.
+   * This nudges each rotated world-object's position so the pivot switch is seamless:
+   * whatever is on screen right now stays there, and only future rotation changes
+   * pivot around the newly selected anchor.
+   */
+  private compensateRotationPivotChange(switchingToViewportCenter: boolean) {
+    if (!this.viewport) {
+      return;
+    }
+
+    this.viewport = this.getRendererScreenPosition();
+    this.updateViewportCenterPoint();
+
+    // The viewport-center pivot actually in effect right now, in screen
+    // space. Switching TO viewport-center always lands on the live
+    // viewportCenterPoint (that's what currentWorldPivot() returns while
+    // idle, and toggling this mode isn't itself a gesture). Switching AWAY
+    // FROM viewport-center: if a gesture -- or the out-of-bounds snap-back
+    // that can still be finishing after one ends, see pivotSwitchPending --
+    // is actively in progress right now, the pivot that's been in effect is
+    // the frozen fixedWorldPivot's *current* screen projection (see
+    // currentWorldPivot's doc comment) -- using viewportCenterPoint directly
+    // here would compute the wrong compensation and jump the object.
+    // Otherwise (idle), it's just viewportCenterPoint, same as the
+    // switching-TO case.
+    const vc =
+      !switchingToViewportCenter && this.pivotPhase !== 'idle' && this.fixedWorldPivot
+        ? this.projectToScreen(this.fixedWorldPivot)
+        : this.viewportCenterPoint;
+
+    this.syncRotationPivotPosition(switchingToViewportCenter ? 'own-center' : vc, switchingToViewportCenter ? vc : 'own-center');
+  }
+
 
   renderer: Renderer;
   world: World;
@@ -168,6 +696,7 @@ export class Runtime {
     },
   };
 
+
   constructor(
     renderer: Renderer,
     world: World,
@@ -211,7 +740,20 @@ export class Runtime {
     this.render(this.lastTime);
     this.startControllers();
     this.homePaddingPx = undefined;
+    this.viewport = this.getRendererScreenPosition();
+    this.updateViewportCenterPoint();
   }
+
+  updateViewportCenterPoint() {
+    // The rotation pivot is applied directly against viewer/screen-space
+    // coordinates in the renderer (see applyTransform), so this must stay
+    // in that same space rather than being converted to world coordinates.
+    this.viewportCenterPoint = {
+      x: (this.viewport?.width || 0) / 2,
+      y: (this.viewport?.height || 0) / 2,
+    };
+  }
+
 
   setHomePosition(position?: Projection) {
     this.homePosition.set(DnaFactory.projection(position ? position : this.world));
@@ -518,7 +1060,6 @@ export class Runtime {
         this.target[4] = Math.round(target.y + fullHeight - space);
       }
     }
-
     this.constrainBounds(this.target);
 
     this.updateControllerPosition();
@@ -968,9 +1509,13 @@ export class Runtime {
    */
   viewerToWorld(x: number, y: number) {
     const scaleFactor = this.getScaleFactor();
-    this._viewerToWorld.x = this.target[1] + x / scaleFactor;
-    this._viewerToWorld.y = this.target[2] + y / scaleFactor;
-    return this._viewerToWorld;
+    // is this right?
+    const xo = this.target[1] + x / scaleFactor;
+    const yo = this.target[2] + y / scaleFactor;
+
+    this._viewerToWorld.x = xo;
+    this._viewerToWorld.y = yo;
+    return { x: xo, y: yo };
   }
 
   /**
@@ -1240,6 +1785,19 @@ export class Runtime {
       pendingUpdate = true;
     }
 
+    // Finalize a pivot switch endInteraction() deferred (see
+    // pivotSwitchPending/finalizePivotSwitch), now that the check above has
+    // given any out-of-bounds snap-back triggered by that gesture's release
+    // a chance to actually start (or, if it turns out there's nothing to
+    // snap back from, a chance to *not* start). Checked here, right after
+    // that step and before getPointsAt() captures this frame's object
+    // positions -- see finalizePivotSwitch's own comment for why it can't
+    // wait until the rotateFromWorldCenter block further down without
+    // lagging a frame behind.
+    if (this.pivotSwitchPending && !this.transitionManager.hasPending()) {
+      this.finalizePivotSwitch();
+    }
+
     if (
       !this.firstRender &&
       !pendingUpdate &&
@@ -1277,6 +1835,33 @@ export class Runtime {
       });
     }
 
+    // The screen-space point actually passed to the renderer as the
+    // rotation pivot for this frame -- see currentWorldPivot's doc comment
+    // for how this tracks the live viewport center while idle, but holds
+    // fixed for the duration of an active pan/zoom transition.
+    let currentRotationPivotScreen: { x: number; y: number } | undefined;
+
+    // Must run before getPointsAt() below, not after: getPointsAt() ->
+    // WorldObject#getAllPointsAt() -> applyRotation() reads each object's
+    // rotationPivot to decide which tile/resolution layer is actually
+    // visible under the current rotation. Updating pivots afterward means
+    // that read sees last frame's pivot, one frame stale relative to the
+    // target this frame is about to render -- harmless while idle (pivot
+    // isn't moving), but during an animated pan/zoom the live pivot moves
+    // every frame, so selection and the actual paint transform (which does
+    // use this frame's pivot -- see CanvasRenderer#applyTransform) disagree
+    // for the whole transition. That mismatch is what let a corner of a
+    // rotated, zoomed-in tile go permanently under-selected -- and thus
+    // rendered from a coarser fallback layer, seen as blur -- once the
+    // transition settled and nothing re-triggered a correcting pass.
+    if (this.rotateFromWorldCenter) {
+      this.viewport = this.getRendererScreenPosition();
+      this.updateViewportCenterPoint();
+      const worldPivot = this.currentWorldPivot();
+      this.updateWorldObjectRotationPivots(worldPivot);
+      currentRotationPivotScreen = worldPivot ? this.projectToScreen(worldPivot) : undefined;
+    }
+
     this.hook('useBeforeFrame', delta);
     // Before everything kicks off, add a hook.
     this.renderer.beforeFrame(this.world, delta, this.target, this.hookOptions);
@@ -1285,6 +1870,7 @@ export class Runtime {
     // Get the points to render based on this scale factor and the current x,y,w,h in the target buffer.
     const points = this.renderer.getPointsAt(this.world, this.target, this.aggregate, scaleFactor);
     const pointsLen = points.length;
+
     for (let p = 0; p < pointsLen; p++) {
       // each point is an array of [SpacialContent, Strand, Strand]
       // The first is used to get real rendering data, like Image URLs etc.
@@ -1302,12 +1888,17 @@ export class Runtime {
       // @todo add option in renderer to omit this transform, instead passing it as a param.
       const position = transformation ? transform(point, transformation, this.transformBuffer) : point;
       // Another hook before painting a layer.
+
+      
+
       this.renderer.prepareLayer(
         paint,
         paint.__parent && transformation
           ? transform(paint.__parent.crop || paint.__parent.points, transformation)
-          : position
+          : position,
+          currentRotationPivotScreen?.x, currentRotationPivotScreen?.y
       );
+
       // For loop helps keep this fast, looping through all of the tiles that make up an image.
       // This could be a single point, where len is one.
       const totalTiles = position.length / 5;

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -209,6 +209,26 @@ export class Runtime {
   private fixedWorldPivot: { x: number; y: number } | undefined;
 
   /**
+   * Set by whichever pan controller is attached (see
+   * PopmotionController's momentum handling) while an inertial/elastic
+   * pan-back-into-bounds animation is actively driving `target` frame by
+   * frame, and cleared once it settles. Momentum drives `target` via
+   * per-frame zero-duration transitions (TransitionManager#customTransition
+   * with total_time = 0) rather than one tracked transition, so it
+   * completes -- and transitionManager.hasPending() goes back to false --
+   * within the same frame it's applied. Left unchecked, the pivotSwitchPending
+   * finalize condition in render() (which exists specifically to wait out an
+   * out-of-bounds snap-back before switching the frozen pivot back to live --
+   * see finalizePivotSwitch) would see hasPending() as false on the very
+   * first frame after release and switch mid-flight, while momentum is still
+   * actively carrying a rotated object back into view -- producing a visible
+   * jump/drift instead of a clean return along the drag's own vector. This
+   * flag gives render() the same visibility into momentum's real lifetime
+   * that it already has into transitionManager's.
+   */
+  panMomentumActive = false;
+
+  /**
    * True from the moment a gesture ends until the pivot has actually
    * finished switching from frozen back to live -- see endInteraction and
    * finalizePivotSwitch. Kept separate from isInteracting (which tracks
@@ -266,17 +286,38 @@ export class Runtime {
     if (this.isInteracting) {
       return;
     }
-    this.isInteracting = true;
     // A previous gesture's pivot switch may still be waiting on its own
-    // out-of-bounds snap-back to settle (see finalizePivotSwitch) -- this
-    // new gesture supersedes it entirely: fixedWorldPivot is about to be
-    // recaptured fresh below, so there's nothing left for that pending
-    // switch to finalize.
+    // out-of-bounds snap-back -- or inertial pan momentum, see
+    // panMomentumActive -- to settle (see finalizePivotSwitch). Captured
+    // *before* isInteracting flips below: isInteracting's own setter drives
+    // pivotPhase, and pivotSwitchPending is a read of that same pivotPhase,
+    // so reading it after would always see 'interacting' and silently miss
+    // a real pending switch.
+    const hadPendingSwitch = this.pivotSwitchPending;
+    this.isInteracting = true;
+    // This new gesture (e.g. a quick click that interrupts an in-flight
+    // momentum glide) must not simply discard a still-pending switch --
+    // unlike a genuinely idle pivot, the object is still actually being
+    // rendered around the OLD frozen pivot right up until this call
+    // (pivotPhase stays 'switching', not 'idle', until finalizePivotSwitch
+    // runs), so dropping pivotSwitchPending without running that
+    // compensation would leave every rotated object rendered one frame
+    // around the old pivot and the next around whatever's live right now,
+    // with no compensating position change in between -- a real, visible
+    // jump (sideways relative to whatever was panning, not toward/away from
+    // it, since it's a pivot change, not a position correction). Finalizing
+    // it here settles that first, so the object's on-screen position is
+    // continuous across the switch.
+    if (hadPendingSwitch) {
+      this.finalizePivotSwitch();
+    }
     this.pivotSwitchPending = false;
     if (this._rotateFromWorldCenter) {
-      // No compensation needed here: this freezes the pivot at whatever the
-      // live pivot is *right now*, so their screen projections coincide by
-      // construction -- nothing has had a chance to drift yet.
+      // No compensation needed here: the pivot is now genuinely live
+      // (either it already was, or finalizePivotSwitch just settled it
+      // above), so freezing it at the live pivot *right now* coincides with
+      // its current screen projection by construction -- nothing left to
+      // drift.
       this.fixedWorldPivot = this.liveWorldPivot();
     }
   }
@@ -1794,7 +1835,14 @@ export class Runtime {
     // positions -- see finalizePivotSwitch's own comment for why it can't
     // wait until the rotateFromWorldCenter block further down without
     // lagging a frame behind.
-    if (this.pivotSwitchPending && !this.transitionManager.hasPending()) {
+    //
+    // Also gated on !panMomentumActive: an inertial/elastic pan-back-into-
+    // bounds animation drives `target` through per-frame zero-duration
+    // transitions, so transitionManager.hasPending() alone is back to false
+    // within the same frame it's set and can't be used, on its own, to tell
+    // whether that animation is still running -- see panMomentumActive's own
+    // comment.
+    if (this.pivotSwitchPending && !this.transitionManager.hasPending() && !this.panMomentumActive) {
       this.finalizePivotSwitch();
     }
 

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -1134,16 +1134,6 @@ export class Runtime {
     this.target[3] = this.target[1] + (this.target[3] - this.target[1]) * widthRatio;
     this.target[4] = this.target[2] + (this.target[4] - this.target[2]) * heightRatio;
 
-    // console.log('resize -> ', toBox(this.target), toBox(this.focalPosition));
-    // 1st bad case
-    // 1302 738 500 500
-    // {x: 0, y: -352.8966979980469, width: 580.4239501953125, height: 1729.7934265136719}
-    // {x: 0, y: 0.0000152587890625, width: 1024, height: 1023.9999847412109}
-    // 2nd bad case
-    // 738 295.9891062144095 500 500
-    // {x: 0, y: 0, width: 295.9891052246094, height: 500}
-    // {x: 119, y: 0, width: 500, height: 500}
-
     this.goHome({ position: this.focalPosition });
     this.renderer.resize(toWidth, toHeight);
     this.pendingUpdate = true;
@@ -1159,21 +1149,6 @@ export class Runtime {
 
       const marginTrimWidth = 0;
       const marginTrimHeight = 0;
-
-      // console.log(widthDiff, heightDiff);
-      // @todo An way to trim margins - breaks reversible resizing.
-      // if (
-      //   (widthDiff || widthDiff === 0) &&
-      //   this.x + this.width > this.world.width &&
-      //   (heightDiff || heightDiff === 0) &&
-      //   this.y + this.height > this.world.height
-      // ) {
-      //   // const maxMarginW = this.width - this.world.width;
-      //   // marginTrimWidth = (maxMarginW < widthDiff ? maxMarginW : widthDiff) * 2;
-      //   // const maxMarginH = this.height - this.world.height;
-      //   // marginTrimHeight = maxMarginH < heightDiff ? maxMarginH : heightDiff;
-      //   // console.log('A');
-      // }
 
       const baseX = this.x + marginTrimWidth;
       const baseY = this.y + marginTrimHeight;

--- a/src/spacial-content/single-image.ts
+++ b/src/spacial-content/single-image.ts
@@ -92,7 +92,9 @@ export class SingleImage extends BaseObject implements SpacialContent {
 
     this.id = props.id || props.uri;
     this.uri = props.uri;
-    this.points.set(DnaFactory.singleBox(props.target.width, props.target.height, props.target.x, props.target.y));
+    const targetX = (props.target.x || 0) + this.pivotCompensationOffset.x;
+    const targetY = (props.target.y || 0) + this.pivotCompensationOffset.y;
+    this.points.set(DnaFactory.singleBox(props.target.width, props.target.height, targetX, targetY));
 
     if (props.style && typeof props.style.opacity !== 'undefined') {
       this.style.opacity = props.style.opacity;

--- a/src/utility/defer-to-microtask.ts
+++ b/src/utility/defer-to-microtask.ts
@@ -1,0 +1,19 @@
+/**
+ * Runs `fn` on the next microtask, unless the returned canceller is called
+ * first. Extracted out of usePreset's React StrictMode double-invoke guard
+ * (see its own comment) so that guard's actual logic -- "defer, but let a
+ * cleanup that runs before the microtask fires cancel it" -- can be unit
+ * tested directly, without needing to render a React tree or reproduce
+ * StrictMode's double-invoke timing.
+ */
+export function deferToMicrotask(fn: () => void): () => void {
+  let cancelled = false;
+  Promise.resolve().then(() => {
+    if (!cancelled) {
+      fn();
+    }
+  });
+  return () => {
+    cancelled = true;
+  };
+}

--- a/src/utility/rotate-strand.ts
+++ b/src/utility/rotate-strand.ts
@@ -4,11 +4,9 @@ export function rotateStrand(strand: Strand, degrees: number, [cx, cy]: [number,
   const newStrand = dna(strand.length);
   const len = strand.length / 5;
   const angle = (degrees * Math.PI) / 180;
-  console.log(len);
 
   for (let i = 0; i < len; i++) {
-    let [, x1, y1, x2, y2] = strand.slice(i * 5, i * 5 + 5);
-    console.log(x1, y1, x2, y2);
+    let [, x1, _y1, _x2, _y2] = strand.slice(i * 5, i * 5 + 5);
 
     const s = Math.sin(angle);
     const c = Math.cos(angle);
@@ -16,14 +14,6 @@ export function rotateStrand(strand: Strand, degrees: number, [cx, cy]: [number,
     // translate point back to origin:
     x1 -= cx;
     x1 -= cy;
-
-    // rotate point
-    const xnew = x1 * c - y1 * s;
-    const ynew = x1 * s + y1 * c;
-
-    // translate point back:
-    console.log(xnew + cx);
-    console.log(ynew + cy);
   }
 
   return newStrand;

--- a/src/world-objects/world-object.ts
+++ b/src/world-objects/world-object.ts
@@ -23,6 +23,51 @@ function rotate(cx: number, cy: number, x: number, y: number, angle: number) {
   return [nx, ny];
 }
 
+/**
+ * Borrowing logic for rotating a point around the center axis: https://danceswithcode.net/engineeringnotes/rotations_in_2d/rotations_in_2d.html
+ * @param x 
+ * @param y 
+ * @param cx 
+ * @param cy 
+ * @param angleDegree 
+ * @returns 
+ */
+export function rotatePoint(
+  x: number,     //X coords to rotate - replaced on return
+  y: number,     //Y coords to rotate - replaced on return
+  cx: number,      //X coordinate of center of rotation
+  cy:number,      //Y coordinate of center of rotation
+  angleDegree: number)   //Angle of rotation (radians, counterclockwise)
+{
+  const radians = (Math.PI * angleDegree)/ 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const nX = ((x-cx)*cos - (y-cy)*sin) + cx;  
+  const nY = ((x - cx) * sin + (y - cy) * cos) + cy;
+  
+  return [nX, nY];
+}
+
+/**
+ * True for a region that can never select anything, in either of the two
+ * shapes getIntersection produces for "these boxes don't overlap":
+ *
+ *  - flagged empty (strand[0] === 0) with its coordinates zeroed out, when
+ *    the boxes miss each other entirely; and
+ *  - flagged *present* but collapsed to zero (or negative) width/height,
+ *    when they merely touch along an edge -- getIntersection's own overlap
+ *    test is inclusive (`<=` / `>=`), so an edge-touch counts as an
+ *    intersection and yields a degenerate box.
+ *
+ * Both mean the same thing to every consumer downstream --
+ * hidePointsOutsideRegion's own comparisons are strict, so neither selects
+ * a single point -- and both must be treated as terminal rather than fed
+ * back into geometry that assumes a real rectangle.
+ */
+function isEmptyRegion(region: Strand) {
+  return region[0] === 0 || region[3] <= region[1] || region[4] <= region[2];
+}
+
 type WorldObjectProps = {
   id: string;
   width: number;
@@ -33,11 +78,76 @@ type WorldObjectProps = {
   rotation?: number;
 };
 
+export type TileSelectionDebugEvent = {
+  ownerId: string;
+  rotation: number;
+  /** The target actually used by getAllPointsAt to select content -- see its comment for why this is intentionally unrotated. */
+  rawTarget: Strand;
+  /**
+   * applyRotation(rawTarget) -- the same rotation-aware bounding target
+   * already used (and tested) for culling in getObjectsAt. NOT necessarily
+   * the "correct" target for content/tile selection (that's an open
+   * question -- see world-object-rotated-tile-selection.test.ts), just the
+   * one candidate reference already trusted elsewhere in this file.
+   */
+  rotationAwareTarget: Strand;
+  /** This object's own (unrotated) bounds in world space. */
+  objectPoints: Strand;
+};
+
+export type HitTestCullingDebugEvent = {
+  ownerId: string;
+  rotation: number;
+  hasExternalPivot: boolean;
+  /** The raw click/touch point (or hit-test box) in un-rotated world space, before applyRotation. */
+  rawTarget: Strand;
+  /** applyRotation(rawTarget) -- rawTarget mapped into this object's own local space, which is what getObjectsAt actually intersects against selectionBounds(). */
+  rotatedTarget: Strand;
+  /** This object's own bounds, widened to cover a pivot-compensated descendant -- see WorldObject#selectionBounds. Equal to this.points when nothing below this node has been pivot-compensated. */
+  objectPoints: Strand;
+  /** Whether rotatedTarget missed selectionBounds() entirely, i.e. the click did not land on this object. */
+  culled: boolean;
+};
+
 export class WorldObject extends BaseObject<WorldObjectProps, Paintable> {
   id: string;
   type = 'world-object';
   scale: number;
   layers: Paintable[];
+
+  /**
+   * Optional debug hook, set by tests/tooling, fired from getAllPointsAt()
+   * whenever a rotated object selects content. Exists to make a real,
+   * reported bug detectable: content/tile selection intentionally ignores
+   * rotation entirely (see getAllPointsAt's own comment), which is correct
+   * for *whether* the object is visible at all, but once zoomed in close to
+   * an edge of a rotated object, the selected sub-region silently stops
+   * matching what's actually on screen -- the renderer then falls back to a
+   * lower-resolution layer for that patch, seen as blur. This hook doesn't
+   * decide what's "correct" itself (that's the real fix, and depends on the
+   * rotation pivot sweep); it just exposes the raw inputs so a test can
+   * check them independently. No-op unless a test/tool sets it.
+   */
+  static debugTileSelection: ((event: TileSelectionDebugEvent) => void) | undefined;
+
+  /**
+   * Optional debug hook, set by tests/tooling, fired from getObjectsAt()
+   * whenever a rotated object hit-tests content. Unlike getAllPointsAt,
+   * getObjectsAt legitimately does rotate the target via applyRotation()
+   * before intersecting it with this.points -- and needs to: its target is
+   * a real click/touch point in raw, un-rotated world space (see its only
+   * callers, world.ts's propagatePointerEvent/propagateTouchEvent), so
+   * mapping it into the object's own local space is exactly how you tell
+   * whether a click landed on this specific object's rotated, pivot-swept
+   * on-screen appearance. (This looked at first like the same rotationPivot
+   * bug that was fixed in getAllPointsAt -- it isn't; that target is a
+   * viewport window, not a point, and needs the opposite treatment. See
+   * world-object-hit-test-rotation-culling.test.ts for the full comparison
+   * and verification against the real render transform.) This hook exposes
+   * both targets and the outcome for tests/tooling to inspect without
+   * duplicating the rotation math. No-op unless a test/tool sets it.
+   */
+  static debugHitTestCulling: ((event: HitTestCullingDebugEvent) => void) | undefined;
 
   /**
    * This position in the world local to the scale of the object.
@@ -54,12 +164,23 @@ export class WorldObject extends BaseObject<WorldObjectProps, Paintable> {
   worldPoints: Strand;
 
   intersectionBuffer = dna(5);
+  selectionBoundsBuffer = dna(5);
+  unionTargetBuffer = dna(5);
   aggregateBuffer = dna(9);
   invertedBuffer = dna(9);
   rotation = 0;
   filteredPointsBuffer: Strand;
   _updatedList: any[] = [];
   geometry?: any;
+
+  /**
+   * World-space coordinates of a fixed external rotation pivot (e.g. the
+   * viewport center), set by Runtime while rotating around a fixed point
+   * instead of this object's own center. undefined means own-center mode.
+   */
+  rotationPivot: { x: number; y: number } | undefined;
+  private lastAppliedX: number | undefined;
+  private lastAppliedY: number | undefined;
 
   constructor(props?: AbstractObject, position?: { x: number; y: number }) {
     super();
@@ -90,9 +211,71 @@ export class WorldObject extends BaseObject<WorldObjectProps, Paintable> {
     return instance;
   }
 
+  /**
+   * BaseObject#applyPivotCompensationOffset moves `points` directly and
+   * bumps `pivotCompensationOffset`, bypassing applyProps() entirely. Left
+   * alone, that desyncs lastAppliedX/Y from pivotCompensationOffset: the
+   * *next* applyProps() call (e.g. from rotating or editing tx/ty) computes
+   * `propsX = props.x + pivotCompensationOffset.x` against a now-stale
+   * lastAppliedX, sees a spurious deltaX/Y equal to the compensation that
+   * was just applied directly, and reapplies it a second time (rotated, per
+   * the screen-aligned-edit logic below) -- an extra jump on the next
+   * unrelated edit, one step removed from the compensation itself. Bumping
+   * lastAppliedX/Y by the same amount keeps that delta at zero.
+   */
+  applyPivotCompensationOffset(x: number, y: number) {
+    super.applyPivotCompensationOffset(x, y);
+    if (this.lastAppliedX !== undefined) {
+      this.lastAppliedX += x;
+      this.lastAppliedY = (this.lastAppliedY as number) + y;
+    }
+  }
+
   applyProps(props: WorldObjectProps) {
-    const x = props.x || 0;
-    const y = props.y || 0;
+    const propsX = (props.x || 0) + this.pivotCompensationOffset.x;
+    const propsY = (props.y || 0) + this.pivotCompensationOffset.y;
+
+    let x: number;
+    let y: number;
+
+    // The angle this update is actually moving to, not this.rotation (the
+    // angle from before this call) -- see the delta un-rotation below.
+    const nextRotation = props.rotation || 0;
+
+    if (this.rotationPivot && this.lastAppliedX !== undefined) {
+      // Rotating around a fixed external pivot means the object's own local
+      // axes are rotated in screen space by the current angle (see
+      // CanvasRenderer#applyTransform) -- moving x/y by a raw amount would
+      // otherwise appear to move the object along the wrong screen axis once
+      // rotated (e.g. a horizontal x edit appearing vertical at 90deg).
+      // Interpreting the *change* in x/y as a screen-space delta and
+      // un-rotating just that delta by the current angle keeps edits
+      // screen-aligned without touching how `rotation` itself sweeps the
+      // object around the fixed pivot (that sweep is a render-time-only
+      // effect and must stay driven by the raw position, not cancelled out
+      // here). Un-rotated by nextRotation, not this.rotation: a call that
+      // changes rotation and position together (e.g. a controller that
+      // rotates and pans in the same update) is about to render at the new
+      // angle, so a position delta arriving in that same call is already a
+      // screen-space delta measured against the angle it's moving *to* --
+      // un-rotating it by the angle it's moving *from* would land it off by
+      // the difference between the two.
+      const deltaX = propsX - this.lastAppliedX;
+      const deltaY = propsY - (this.lastAppliedY as number);
+      // rotatePoint(deltaX, deltaY, 0, 0, -nextRotation) un-rotates the
+      // delta around the origin -- same formula as the two call sites in
+      // Runtime#syncRotationPivotPosition, reused here instead of a third
+      // hand-written copy (see that method's own comment on why).
+      const [rotatedDeltaX, rotatedDeltaY] = rotatePoint(deltaX, deltaY, 0, 0, -nextRotation);
+      x = this.x + rotatedDeltaX;
+      y = this.y + rotatedDeltaY;
+    } else {
+      x = propsX;
+      y = propsY;
+    }
+
+    this.lastAppliedX = propsX;
+    this.lastAppliedY = propsY;
 
     if (typeof props.id !== 'undefined') {
       this.id = props.id;
@@ -104,7 +287,7 @@ export class WorldObject extends BaseObject<WorldObjectProps, Paintable> {
     this.points[2] = y;
     this.points[3] = x + props.width;
     this.points[4] = y + props.height;
-    this.rotation = props.rotation || 0;
+    this.rotation = nextRotation;
 
     this.worldPoints[3] = this.worldPoints[1] + props.width;
     this.worldPoints[4] = this.worldPoints[2] + props.height;
@@ -158,11 +341,49 @@ export class WorldObject extends BaseObject<WorldObjectProps, Paintable> {
   }
 
   getObjectsAt(target: Strand, all?: boolean): Paintable[] {
+    const rawTarget = target;
+    // Rotating `target` itself here is unrelated to the widening below --
+    // this maps a real click point into *this* node's own local space,
+    // which only makes sense when this node is itself the rotated one (see
+    // this method's own file-level comment in
+    // world-object-hit-test-rotation-culling.test.ts for the full
+    // rawTarget-vs-viewport-window distinction from getAllPointsAt). An
+    // unrotated ancestor's own local space isn't rotated at all, so its
+    // click target is left as-is; selectionBounds() below is what lets it
+    // still recognize a click on a rotated, pivot-compensated descendant.
     if (this.rotation) {
       target = this.applyRotation(target);
     }
 
-    const filteredPoints = hidePointsOutsideRegion(this.points, target, this.filteredPointsBuffer);
+    // Culled against selectionBounds(), not this.points -- see its own
+    // comment. this.points goes stale the moment a descendant is
+    // pivot-compensated (Runtime#syncRotationPivotPosition moves only the
+    // actually-rotated node), the same staleness getAllPointsAt was fixed
+    // to account for. Left as this.points here, a click on content that is
+    // genuinely on screen -- painted correctly by the already-fixed
+    // getAllPointsAt -- would still be silently culled before ever
+    // reaching the descendant whose own hit-test would have found it.
+    const bounds = this.selectionBounds();
+    const filteredPoints = hidePointsOutsideRegion(bounds, target, this.filteredPointsBuffer);
+
+    const widened =
+      bounds[1] !== this.points[1] ||
+      bounds[2] !== this.points[2] ||
+      bounds[3] !== this.points[3] ||
+      bounds[4] !== this.points[4];
+
+    if ((this.rotation || widened) && WorldObject.debugHitTestCulling) {
+      WorldObject.debugHitTestCulling({
+        ownerId: this.id,
+        rotation: this.rotation,
+        hasExternalPivot: !!this.rotationPivot,
+        rawTarget: rawTarget.slice() as Strand,
+        rotatedTarget: target.slice() as Strand,
+        objectPoints: bounds.slice() as Strand,
+        culled: filteredPoints[0] === 0,
+      });
+    }
+
     if (filteredPoints[0] === 0) {
       return [];
     }
@@ -196,20 +417,211 @@ export class WorldObject extends BaseObject<WorldObjectProps, Paintable> {
     return objects;
   }
 
-  applyRotation(target: Strand) {
+  /**
+   * The rotation angle getAllPointsAt's selection widening should use --
+   * ordinarily this.rotation, but falls back to a descendant's rotation
+   * when this node itself isn't rotated.
+   *
+   * Render-time rotation is applied by whichever WorldObject is the
+   * *nearest* owner of the paint (see CanvasRenderer#applyTransform), which
+   * is not necessarily this node -- e.g. ImageService renders its rotation
+   * onto its own nested wrapper (see TileSet.tsx), which can itself sit
+   * *two* plain, unrotated <world-object> levels below where a story
+   * places it (confirmed live: a bare wrapper around an ImageService, whose
+   * own wrapper is what actually carries the rotation). Each unrotated
+   * level's own this.rotation is 0, so without this fallback its
+   * getAllPointsAt skips rotation-aware widening entirely (applyRotation is
+   * a no-op when rotation is falsy) and hands its child an
+   * already-narrowed, zero-rotation-aware target -- no amount of a
+   * *descendant's* own correct widening can recover content already
+   * clipped away higher up by an ancestor's getIntersection. Recursing into
+   * this same method on each child (rather than reading child.rotation
+   * directly) is what lets this see through any number of intermediate
+   * unrotated wrappers to the rotation that's actually being rendered,
+   * however many levels down it lives -- confirmed as the real depth
+   * needed here, not merely one level, against the actual failing case
+   * (see world-object-nested-rotation-selection.test.ts).
+   *
+   * Deliberately not folded into applyRotation() itself: that method also
+   * backs getObjectsAt's hit-testing, which already has its own carefully
+   * verified (and differently-shaped) rotation handling -- see
+   * world-object-hit-test-rotation-culling.test.ts. This only widens
+   * *selection*, leaving hit-testing untouched.
+   *
+   * Not private: World#getObjectsAt calls this too, on every top-level
+   * object, for the exact same reason one level up -- see its own comment.
+   */
+  selectionRotation(): number {
     if (this.rotation) {
+      return this.rotation;
+    }
+    for (const layer of this.layers) {
+      if (!layer) {
+        continue;
+      }
+      const rotation =
+        typeof (layer as any).selectionRotation === 'function'
+          ? ((layer as unknown) as WorldObject).selectionRotation()
+          : (layer as any).rotation;
+      if (rotation) {
+        return rotation;
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * This node's own bounds, widened to wherever its subtree is actually
+   * rendered -- the region getAllPointsAt must intersect `target` against,
+   * in place of `this.points`.
+   *
+   * `this.points` stops describing a node's own content the moment the
+   * rotation pivot changes: Runtime#syncRotationPivotPosition compensates
+   * for that change by moving the *rotated* node (the only one whose
+   * on-screen position the pivot actually affects -- see its
+   * `if (owner.rotation)`), and rotation lives on a nested wrapper, not on
+   * the top-level object (ImageService renders its rotation onto TileSet's
+   * own inner wrapper -- the same nesting selectionRotation exists for).
+   * Every ancestor of that wrapper keeps the bounds it had before, now
+   * describing where its content *used* to be. Measured live against
+   * stories/sequence-panel.stories.tsx's "setup test2": a canvas whose
+   * top-level object still claimed x 2451..4862 while the tiles it owns
+   * were being painted from x 1850 -- a 601px lie, easily enough for
+   * getIntersection to miss a target that genuinely overlaps the content,
+   * and cull a whole visibly on-screen canvas at the very first level.
+   * (World#forceIncludeRotatedObjects is the same staleness one level
+   * further up, handled the same way: keep the candidate, let real
+   * geometry decide.)
+   *
+   * Only ever widens, and only to cover content that genuinely exists, so
+   * the "genuinely far away is still culled" guarantee is untouched -- an
+   * object whose *content* is off screen still has every one of these
+   * bounds off screen (see world-object-culling.test.ts). Recurses through
+   * child world-objects the same way (and for the same reason)
+   * selectionRotation does, since the compensated node can be any number of
+   * levels down; child bounds are mapped back into this node's own frame
+   * with the inverse of the transform getAllPointsAt applies on the way
+   * down (`child = (parent - x) / scale`). Layers that aren't
+   * world-objects are skipped: pivot compensation never touches them, and
+   * a tiled leaf's `points` is a whole grid rather than one box.
+   */
+  selectionBounds(): Strand {
+    const bounds = this.selectionBoundsBuffer;
+    bounds[0] = this.points[0];
+    bounds[1] = this.points[1];
+    bounds[2] = this.points[2];
+    bounds[3] = this.points[3];
+    bounds[4] = this.points[4];
+
+    const len = this.layers.length;
+    for (let i = 0; i < len; i++) {
+      const layer = this.layers[i] as any;
+      if (!layer || typeof layer.selectionBounds !== 'function') {
+        continue;
+      }
+      const child = layer.selectionBounds() as Strand;
+      const x1 = child[1] * this.scale + this.x;
+      const y1 = child[2] * this.scale + this.y;
+      const x2 = child[3] * this.scale + this.x;
+      const y2 = child[4] * this.scale + this.y;
+      if (x1 < bounds[1]) bounds[1] = x1;
+      if (y1 < bounds[2]) bounds[2] = y1;
+      if (x2 > bounds[3]) bounds[3] = x2;
+      if (y2 > bounds[4]) bounds[4] = y2;
+    }
+
+    return bounds;
+  }
+
+  /**
+   * getAllPointsAt needs both selectionRotation() and selectionBounds()
+   * every call, and each independently walks this node's *entire* child
+   * subtree -- calling both back-to-back (as getAllPointsAt used to) means
+   * two full traversals per node per frame, on top of each child's own
+   * getAllPointsAt call independently redoing the same two traversals one
+   * level down. This computes both in a single walk instead, halving that
+   * specific redundancy.
+   *
+   * Purely an internal optimization: selectionRotation() and
+   * selectionBounds() above keep their own existing behavior and signature
+   * unchanged (so a caller that only wants one of the two, like
+   * World#forceIncludeRotatedObjects wanting only rotation, isn't made to
+   * pay for the other), and this method's own per-layer conditions
+   * (typeof layer.selectionRotationAndBounds/rotation, typeof
+   * layer.selectionBounds) mirror theirs exactly, so results match call
+   * for call. Not exposed beyond getAllPointsAt: two independent recursive
+   * implementations of the same walk is exactly the kind of thing that
+   * silently drifts (see this file's own rotate()/rotatePoint() history),
+   * so there is deliberately only one -- selectionRotation() and
+   * selectionBounds() stay as the source of truth for anything outside
+   * this hot path.
+   */
+  private selectionRotationAndBounds(): { rotation: number; bounds: Strand } {
+    const bounds = this.selectionBoundsBuffer;
+    bounds[0] = this.points[0];
+    bounds[1] = this.points[1];
+    bounds[2] = this.points[2];
+    bounds[3] = this.points[3];
+    bounds[4] = this.points[4];
+
+    let rotation = this.rotation;
+
+    const len = this.layers.length;
+    for (let i = 0; i < len; i++) {
+      const layer = this.layers[i] as any;
+      if (!layer) {
+        continue;
+      }
+
+      if (typeof layer.selectionRotationAndBounds === 'function') {
+        const child = layer.selectionRotationAndBounds() as { rotation: number; bounds: Strand };
+        if (!rotation && child.rotation) {
+          rotation = child.rotation;
+        }
+        const x1 = child.bounds[1] * this.scale + this.x;
+        const y1 = child.bounds[2] * this.scale + this.y;
+        const x2 = child.bounds[3] * this.scale + this.x;
+        const y2 = child.bounds[4] * this.scale + this.y;
+        if (x1 < bounds[1]) bounds[1] = x1;
+        if (y1 < bounds[2]) bounds[2] = y1;
+        if (x2 > bounds[3]) bounds[3] = x2;
+        if (y2 > bounds[4]) bounds[4] = y2;
+      } else if (!rotation && layer.rotation) {
+        // Matches selectionRotation()'s own fallback for a layer that
+        // isn't a WorldObject (e.g. a leaf with its own .rotation): it can
+        // still contribute a rotation to widen selection with, but -- like
+        // selectionBounds() -- never contributes to bounds, since pivot
+        // compensation only ever moves a WorldObject wrapper's own x/y.
+        rotation = layer.rotation;
+      }
+    }
+
+    return { rotation, bounds };
+  }
+
+  applyRotation(target: Strand, rotationOverride?: number) {
+    const rotation = typeof rotationOverride === 'number' ? rotationOverride : this.rotation;
+    if (rotation) {
       const a = { x: target[1], y: target[2] };
       const b = { x: target[1], y: target[4] };
       const c = { x: target[3], y: target[2] };
       const d = { x: target[3], y: target[4] };
 
-      const x = this.points[1] + (this.points[3] - this.points[1]) / 2;
-      const y = this.points[2] + (this.points[4] - this.points[2]) / 2;
+      // Visibility/culling must rotate the viewport window around whatever
+      // point this object is actually *rendered* rotated around. Normally
+      // that's the object's own center, but while rotating around a fixed
+      // external pivot (rotationPivot, set by Runtime -- see
+      // CanvasRenderer#applyTransform), using the own-center here instead
+      // would compute a completely different (and often non-overlapping)
+      // effective target, silently culling an object that's actually on
+      // screen.
+      const x = this.rotationPivot ? this.rotationPivot.x : this.points[1] + (this.points[3] - this.points[1]) / 2;
+      const y = this.rotationPivot ? this.rotationPivot.y : this.points[2] + (this.points[4] - this.points[2]) / 2;
 
-      const [x1, y1] = rotate(x, y, a.x, a.y, this.rotation);
-      const [x2, y2] = rotate(x, y, b.x, b.y, this.rotation);
-      const [x3, y3] = rotate(x, y, c.x, c.y, this.rotation);
-      const [x4, y4] = rotate(x, y, d.x, d.y, this.rotation);
+      const [x1, y1] = rotate(x, y, a.x, a.y, rotation);
+      const [x2, y2] = rotate(x, y, b.x, b.y, rotation);
+      const [x3, y3] = rotate(x, y, c.x, c.y, rotation);
+      const [x4, y4] = rotate(x, y, d.x, d.y, rotation);
 
       const rx1 = Math.min(x1, x2, x3, x4);
       const rx2 = Math.max(x1, x2, x3, x4);
@@ -224,22 +636,150 @@ export class WorldObject extends BaseObject<WorldObjectProps, Paintable> {
   getAllPointsAt(target: Strand, aggregate: Strand, scaleFactor: number): Paint[] {
     const transformer = compose(translate(this.x, this.y), scale(this.scale), this.aggregateBuffer);
 
-    if (this.rotation) {
-      target = this.applyRotation(target);
+    // Rotation is intentionally NOT applied to `target` for this primary
+    // selection. Render-time position (CanvasRenderer's
+    // `position`/`transform(point, transformation)`) is always a
+    // translate+scale-only composition through the whole ancestor chain --
+    // rotation is applied separately, once, as a post-hoc screen-space
+    // canvas transform (see CanvasRenderer#applyTransform). Rotating target
+    // here to match `this.rotation` duplicates that transform one stage too
+    // early, and -- because a fixed external pivot can be far from this
+    // node's own bounds -- can shift the computed region completely outside
+    // `this.points`, incorrectly culling content that is actually on screen
+    // once the real (post-hoc) rotation is applied. This unrotated pass is
+    // therefore a deliberately conservative baseline: it always selects
+    // *something* for a genuinely visible rotated object, at the cost of
+    // sometimes selecting the wrong sub-region once zoomed in close to an
+    // edge (the renderer then falls back to a lower-resolution layer there,
+    // seen as blur -- see world-object-rotated-tile-selection.test.ts).
+    // Rotation-aware region: the sub-region actually visible once the
+    // post-hoc rotation is applied (target mapped into this object's own
+    // local space the same way getObjectsAt already does for hit-testing --
+    // see world-object-hit-test-rotation-culling.test.ts). applyRotation
+    // returns `target` itself, unchanged, when the effective rotation is
+    // falsy -- selectionRotation() falls back to a direct child's rotation
+    // when this node isn't rotated itself; see its own comment for why an
+    // unrotated node containing a rotated child still needs to widen here.
+    //
+    // Widening is skipped outright for a target that already selects
+    // nothing -- see isEmptyRegion: rotating an empty region is not a
+    // no-op, it *moves* it (to somewhere else entirely, when the pivot is
+    // far away), and the union of "nothing here" with "nothing over there"
+    // is a real, non-empty rectangle. That resurrects an already-made
+    // decision as a bogus one: this node's getIntersection then clips that
+    // rectangle against its own bounds into a thin sliver at one edge and
+    // selects (paints, and network-loads tiles for) the handful of leaves
+    // nearest it. Observed live against
+    // stories/sequence-panel.stories.tsx's "setup test2": a canvas the
+    // widened target genuinely missed still selected five tiles, two levels
+    // below the empty intersection that should have ended it -- and from
+    // the wrong end of its grid, since nothing about that sliver's position
+    // has anything to do with what's on screen. That path only opened up
+    // once World#forceIncludeRotatedObjects started
+    // deliberately keeping rotated top-level objects as candidates
+    // regardless of their raw bounds, specifically so this method could
+    // make the real decision -- "nothing" has to be one of the decisions
+    // it's allowed to make and have stick.
+    // A combined computation of selectionRotation() + selectionBounds() --
+    // see selectionRotationAndBounds's own comment for why this hot path
+    // uses it instead of the two public methods separately.
+    const { rotation, bounds: ownBounds } = this.selectionRotationAndBounds();
+    const emptyTarget = isEmptyRegion(target);
+    const rotationAwareTarget = emptyTarget ? target : this.applyRotation(target, rotation);
+
+    if (rotation && !emptyTarget && WorldObject.debugTileSelection) {
+      WorldObject.debugTileSelection({
+        ownerId: this.id,
+        rotation,
+        rawTarget: target.slice() as Strand,
+        rotationAwareTarget: rotationAwareTarget.slice() as Strand,
+        objectPoints: this.points.slice() as Strand,
+      });
     }
 
-    const inter = getIntersection(target, this.points, this.intersectionBuffer);
+    // Selects against target ∪ rotationAwareTarget in a single pass, rather
+    // than running getAllPointsAt against each independently and
+    // concatenating the results (an earlier version of this fix did that,
+    // to additionally catch the rotation-aware sub-region without narrowing
+    // what the conservative unrotated pass already found). That turned out
+    // to be a real correctness bug, not just "a little redundant work" as
+    // originally assumed here: it doubles up selection of the same content
+    // (confirmed live: ~2.5x as many drawImage calls per render for the
+    // same on-screen content), and each pass does its own independent
+    // coarse-to-fine layer selection with no ordering guarantee *between*
+    // the two passes -- so a later pass's coarse fallback tile can paint
+    // over an earlier pass's already-fine tile at the same screen position.
+    // Confirmed live via drawImage instrumentation watching the actual
+    // story across several render ticks after rotating: dozens of cases of
+    // a native-resolution tile immediately followed by an overlapping,
+    // smoothed lower-resolution one -- exactly the intermittent per-tile
+    // blur this was meant to fix, reintroduced by the fix itself. A single
+    // selection pass selects (and thus paints) each layer once, with one
+    // coherent coarse-to-fine ordering, so this can't happen; the tradeoff
+    // is that the union's bounding box can select a little more area than
+    // the two rects strictly cover when they're far apart (e.g. a distant
+    // rotation pivot), which is extra harmless work, not a correctness
+    // issue.
+    let unionTarget = target;
+    if (rotationAwareTarget !== target) {
+      // Written into a reusable buffer rather than dna([...]) -- this runs
+      // for every rotated (or rotation-descendant-carrying) node, every
+      // frame, and a fresh Float32Array allocation here on that path is
+      // exactly the per-frame GC pressure this class otherwise avoids (see
+      // e.g. Runtime#updateWorldObjectRotationPivots's own comment on
+      // reusing rotationPivot objects for the same reason).
+      unionTarget = this.unionTargetBuffer;
+      unionTarget[0] = target[0];
+      unionTarget[1] = Math.min(target[1], rotationAwareTarget[1]);
+      unionTarget[2] = Math.min(target[2], rotationAwareTarget[2]);
+      unionTarget[3] = Math.max(target[3], rotationAwareTarget[3]);
+      unionTarget[4] = Math.max(target[4], rotationAwareTarget[4]);
+    }
+
+    // Intersected against where this node's content actually is, not
+    // against `this.points` -- see selectionBounds for why those two stop
+    // agreeing (and by how much) as soon as anything below this node has
+    // been pivot-compensated. Identical to this.points for every node that
+    // hasn't been. Reuses ownBounds (already computed above alongside
+    // rotation) rather than calling selectionBounds() again, which would
+    // redo the same subtree walk a second time in this same call.
+    const inter = getIntersection(unionTarget, ownBounds, this.intersectionBuffer);
+
+    // Nothing of this object lies inside the (already widened) selection
+    // region, so nothing below it can be visible either -- stop here rather
+    // than recursing with an empty region. Descending with one is not
+    // harmless: the inverse transform below *moves* an empty region (its
+    // coordinates are zeroed, so a translate lands it on the parent's own
+    // offset rather than leaving it nowhere), getIntersection's overlap
+    // test is inclusive, so re-intersecting that point against a child's
+    // bounds hands back a zero-area box flagged as a real intersection, and
+    // hidePointsOutsideRegion's strict comparisons *do* match any tile that
+    // straddles it -- so a handful of leaves around an arbitrary interior
+    // point get selected, painted, and their tiles fetched, several levels
+    // below the miss that should have ended it. Nothing further down the
+    // selection path can undo that, because by then it no longer looks like
+    // a mistake: it's a real region, inside real bounds.
+    //
+    // Returning no paints at all (rather than every layer's paints marked
+    // culled) is the same thing this object's ancestors already do when
+    // *they* find no overlap -- World#getObjectsAt/#getAllPointsAt simply
+    // never descend into an object hidePointsOutsideRegion excluded -- so
+    // it's a shape the renderer already handles for every off-screen
+    // object; see world-object-culling.test.ts.
+    if (isEmptyRegion(inter)) {
+      return [];
+    }
+
     const len = this.layers.length;
     const arr: Paint[] = [];
-
     const t = transform(inter, compose(scale(1 / this.scale), translate(-this.x, -this.y), this.invertedBuffer));
     const agg = aggregate ? compose(aggregate, transformer, this.aggregateBuffer) : transformer;
     const s = scaleFactor * this.scale;
 
     for (let i = 0; i < len; i++) {
-      // Crop intersection.
       arr.push(...this.layers[i].getAllPointsAt(t, agg, s));
     }
+
     return arr;
   }
 

--- a/src/world-objects/zone.ts
+++ b/src/world-objects/zone.ts
@@ -92,6 +92,13 @@ export class Zone implements ZoneInterface {
   }
 
   recalculateBounds(): void {
+    // Main's Zone was redesigned upstream (config-driven manual bounds via
+    // this.config.x/y/width/height) since touch-old forked -- it no longer
+    // computes bounds from this.objects's own points at all, so the
+    // selectionBounds()-based fix from that branch (a member WorldObject's
+    // raw .points going stale once a rotated descendant is
+    // pivot-compensated -- see WorldObject#selectionBounds) doesn't apply
+    // here: there's no per-object .points read left for it to widen.
     const hasManualBounds =
       Number.isFinite(this.config.x) &&
       Number.isFinite(this.config.y) &&

--- a/src/world.ts
+++ b/src/world.ts
@@ -404,7 +404,6 @@ export class World extends BaseObject<WorldProps, WorldObject> {
       }
       this.needsRecalculate = false;
     }
-
     return didChange;
   }
 
@@ -508,9 +507,62 @@ export class World extends BaseObject<WorldProps, WorldObject> {
     };
   }
 
+  /**
+   * Forces every rotated (or rotated-descendant-carrying -- see
+   * WorldObject#selectionRotation) top-level object's slot in `filteredPoints`
+   * to stay marked included, undoing hidePointsOutsideRegion's raw-bounds
+   * exclusion for those objects specifically.
+   *
+   * World has no rotation of its own, so getObjectsAt/getScheduledUpdates
+   * otherwise filter top-level objects with a single
+   * hidePointsOutsideRegion(this.points, target) call against each object's
+   * *raw, unrotated* world bounds -- exactly like an unrotated WorldObject
+   * before selectionRotation() existed, just one level higher, with nothing
+   * above World left to widen on its behalf.
+   *
+   * An earlier version of this fix tried widening `target` itself first (by
+   * unioning in applyRotation(target) computed per rotated object, the same
+   * trick WorldObject#getAllPointsAt already uses one level down) rather
+   * than force-including here. That's a real, but *narrower*, technique
+   * than it looks: it only discovers a raw region genuinely reachable by
+   * rotating target around the pivot currently in effect -- while idle,
+   * that pivot is *always* target's own center (see currentWorldPivot's own
+   * doc comment), and rotating any rectangle around its own center can
+   * never move its bounding box beyond swapping its own width and height.
+   * Confirmed live: after dragging (pans target in raw world-space,
+   * uncorrelated with visual rotation -- the controller has no rotation
+   * awareness either) far enough that a top-level object's raw bounds no
+   * longer overlap target at all, no rotation of target around its own
+   * center can ever reach back to it, however the pivot or angle are
+   * chosen -- the widening was geometrically incapable of the one thing it
+   * needed to do. Forcing inclusion instead sidesteps needing that
+   * calculation to be right at all: a rotated object's own
+   * getObjectsAt/getAllPointsAt already does its own correct, precise
+   * filtering against the real target once it actually runs (see
+   * WorldObject#applyRotation and #selectionRotation) -- this only has to
+   * stop the fast, rotation-*unaware* pre-filter up here from silently
+   * dropping a candidate before that downstream logic ever gets a chance.
+   * Only ever adds candidates, never removes any hidePointsOutsideRegion
+   * already kept -- unrotated objects (the common case, and the only case
+   * where the raw-bounds fast path is actually a correctness-preserving
+   * optimization) are entirely unaffected.
+   */
+  private forceIncludeRotatedObjects(filteredPoints: Strand) {
+    const len = this.objects.length;
+    for (let index = 0; index < len; index++) {
+      const object = this.objects[index];
+      if (!object || object.type !== 'world-object') {
+        continue;
+      }
+      if ((object as WorldObject).selectionRotation()) {
+        filteredPoints[index * 5] = 1;
+      }
+    }
+  }
+
   getScheduledUpdates(target: Strand, scaleFactor: number): Array<() => void | Promise<void>> {
     const filteredPoints = hidePointsOutsideRegion(this.points, target, this.filteredPointsBuffer);
-
+    this.forceIncludeRotatedObjects(filteredPoints);
     const len = this.objects.length;
     this._updatedList = [];
 
@@ -548,6 +600,7 @@ export class World extends BaseObject<WorldProps, WorldObject> {
     const zone = this.getActiveZone();
     const includeOutsideObjects = zone && includeZoneFade ? this.getZoneOutsideVisibility(zone) > 0 : false;
     const filteredPoints = hidePointsOutsideRegion(this.points, target, this.filteredPointsBuffer);
+    this.forceIncludeRotatedObjects(filteredPoints);
 
     const len = this.renderOrder.length;
     const objects: Array<[WorldObject, Paintable[]]> = [];

--- a/stories/rotation.stories.tsx
+++ b/stories/rotation.stories.tsx
@@ -11,6 +11,14 @@ const tile = {
   height: 2743,
 };
 
+
+const welcomeTile = {
+  id: 'https://iiif.wellcomecollection.org/image/b18035723_0001.JP2/info.json',
+  height: 3543,
+  width: 2569,
+};
+
+
 function Container(props: { children: ReactNode; style?: any }) {
   return (
     <>
@@ -28,7 +36,7 @@ function Container(props: { children: ReactNode; style?: any }) {
   );
 }
 
-function Slider({ control, label, ...props }: any) {
+function Slider({ control, label, max = 2000, ...props }: any) {
   const [state, setState] = control;
   return (
     <div style={{ display: 'flex' }}>
@@ -36,7 +44,7 @@ function Slider({ control, label, ...props }: any) {
       <input
         type="range"
         min={0}
-        max={359}
+        max={max}
         value={state}
         onChange={(e) => setState(e.target.valueAsNumber)}
         {...props}
@@ -52,6 +60,7 @@ export const CropRotateStaticImageInteractive = () => {
   const rotation = useState(5);
   const x = useState(120);
   const tx = useState(123);
+  const ty = useState(123);
   const utx = useState(0);
   const y = useState(0);
   const scale = useState(100);
@@ -59,17 +68,26 @@ export const CropRotateStaticImageInteractive = () => {
   const [rt, setRt] = useState<Preset>();
   const debug = useRef<HTMLDivElement>(null);
   const [key, setKey] = useState(0);
+  const [rotateFromWorldCenter, setRotateFromWorldCenter] = useState(false);
 
   const scaleFactor = scale[0] / 100;
 
+  const handleCheckboxChange = (event: { target: { checked: boolean | ((prevState: boolean) => boolean); }; }) => {
+    setRotateFromWorldCenter(event.target.checked);
+  };
+
   return (
     <>
-      <Slider control={rotation} label="rotation" />
+      <Slider control={rotation} label="rotation" max="359"/>
       <Slider control={x} label="x" />
       <Slider control={scale} label="scale" />
       <Slider control={tx} label="tx" />
+      <Slider control={ty} label="ty" />
       <Slider control={utx} label="Unsupported translation" />
       <Slider control={y} label="y" />
+
+      <strong>Rotate From Center? </strong>&nbsp;<input type="checkbox" checked={rotateFromWorldCenter} onChange={handleCheckboxChange} />
+      <br/>
       <button
         onClick={() => {
           setKey((i) => i + 1);
@@ -79,32 +97,138 @@ export const CropRotateStaticImageInteractive = () => {
         render
       </button>
       <div ref={debug}>debug</div>
-      <Container style={{ height: 512, width: 512 }}>
+     <Container style={{ height: 512, width: 512 }}>
         <AtlasAuto
           renderPreset={preset}
+          rotateFromWorldCenter={rotateFromWorldCenter}
           onCreated={(e) => {
             ref.current = e;
             setRt(e);
           }}
         >
           <world>
-            <world-object key={key} scale={scaleFactor} height={450} width={300} x={tx[0]} y={0} rotation={rotation[0]}>
-              <world-image
-                uri={img}
-                target={{ width: 600, height: 900, x: utx[0], y: 0 }}
-                display={{ width: 600, height: 900, x: 0, y: 0 }}
-                crop={{
-                  x: x[0],
-                  y: y[0],
-                  width: 300,
-                  height: 450,
-                }}
+            <world-object
+              key={key}
+              scale={scaleFactor}
+              height={tile.height / 2}
+              width={tile.width / 2}
+              x={tx[0]}
+              y={ty[0]}
+              rotation={rotation[0]}
+            >
+              <ImageService
+                key="wunder"
+                {...welcomeTile}
+                crop={{ x: x[0], y: y[0], width: tile.width / 2, height: tile.height / 2 }}
+                rotation={rotation[0]}
               />
-              <box style={{ border: '2px solid red' }} target={{ width: 300 - 4, height: 450 - 4, x: utx[0], y: 0 }} />
+              <box
+                style={{ border: '2px solid red' }}
+                target={{ width: tile.width / 2 - 4, height: tile.height / 2 - 4, x: utx[0], y: 0 }}
+              />
             </world-object>
           </world>
         </AtlasAuto>
       </Container>
+
+    </>
+  );
+};
+
+
+
+import { useLayoutEffect } from 'react';
+import { Runtime } from '../src/renderer/runtime';
+
+export const CropImageBroken = () => {
+  const rotation = useState(87);
+  const x = useState(120);
+  const tx = useState(2000);
+  const ty = useState(2000);
+  const utx = useState(0);
+  const y = useState(0);
+  let scale = useState(2000);
+  const ref = useRef<Preset>();
+  const [rt, setRt] = useState<Runtime>();
+  const debug = useRef<HTMLDivElement>(null);
+  const [key, setKey] = useState(0);
+  const [zoom, setZoom] = useState(1);
+  const [rotateFromWorldCenter, setRotateFromWorldCenter] = useState(true);
+
+  const scaleFactor = scale[0] / 100;
+
+  const handleCheckboxChange = (event: { target: { checked: boolean | ((prevState: boolean) => boolean); }; }) => {
+    setRotateFromWorldCenter(event.target.checked);
+  };
+
+  const zoomBy = (factor: number) => {
+    if (ref) {
+      ref.current?.runtime?.transitionManager.zoomTo(factor);
+    }
+  
+  };
+
+  
+  return (
+    <>
+      <Slider control={rotation} label="rotation" max="359"/>
+      <Slider control={x} label="x" />
+      <Slider control={scale} label="scale" />
+      <Slider control={tx} label="tx" />
+      <Slider control={ty} label="ty" />
+      <Slider control={utx} label="Unsupported translation" />
+      <Slider control={y} label="y" />
+      
+      <button onClick={() => zoomBy(1 / 1.5)}>Zoom in</button>
+      <button onClick={() => zoomBy(1.3)}>Zoom out</button>
+
+
+      <strong>Rotate From Center? </strong>&nbsp;<input type="checkbox" checked={rotateFromWorldCenter} onChange={handleCheckboxChange} />
+      <br/>
+      <button
+        onClick={() => {
+          setKey((i) => i + 1);
+          ref.current?.runtime.world.recalculateWorldSize();
+        }}
+      >
+        render
+      </button>
+      <div ref={debug}>debug</div>
+     <Container style={{ height: 512, width: 512 }}>
+        <AtlasAuto
+          renderPreset={preset}
+          rotateFromWorldCenter={rotateFromWorldCenter}
+          onCreated={(e) => {
+            ref.current = e;
+            setRt(e);
+            scale = 468;
+          }}
+        >
+          <world>
+            <world-object
+              key={key}
+              scale={scaleFactor}
+              height={tile.height / 2}
+              width={tile.width / 2}
+              x={tx[0]}
+              y={ty[0]}
+              rotation={rotation[0]}
+            >
+              <ImageService
+                key="wunder"
+                {...welcomeTile}
+                crop={{ x: x[0], y: y[0], width: tile.width / 2, height: tile.height / 2 }}
+                rotation={rotation[0]}
+              />
+              <box
+                style={{ border: '2px solid red' }}
+                target={{ width: tile.width / 2 - 4, height: tile.height / 2 - 4, x: utx[0], y: 0 }}
+              />
+            </world-object>
+          </world>
+        </AtlasAuto>
+      </Container>
+
     </>
   );
 };

--- a/stories/sequence-panel.stories.tsx
+++ b/stories/sequence-panel.stories.tsx
@@ -1,0 +1,1159 @@
+import * as React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { dna } from '@atlas-viewer/dna';
+import {
+  AtlasAuto,
+  CanvasRenderer,
+  HitTestCullingDebugEvent,
+  ImageService,
+  ImageStretchDebugEvent,
+  isImageStretched,
+  Preset,
+  TileLoadDebugEvent,
+  TileSelectionDebugEvent,
+  WorldObject,
+} from '../src/index';
+import { getVaultHelper } from '../src/modules/iiif/get-vault-helper';
+import type { AnnotationNormalized, AnnotationPageNormalized, CanvasNormalized } from '@iiif/presentation-3-normalized';
+
+// Resolves a canvas's painting image service id straight from the vault.
+// (Not using get-tiles.ts's getTileFromCanvas here - it assumes the
+// service snippet always has an `id`, but embedded IIIF Image API v2
+// services - like the ones on this manifest - use `@id` instead, which
+// throws. Left get-tiles.ts untouched and just handle both forms here.)
+function getCanvasImageServiceId(canvas: CanvasNormalized, vault: any): string | undefined {
+  for (const pageRef of canvas.items) {
+    const page = vault.get<AnnotationPageNormalized>(pageRef);
+    for (const annoRef of page.items) {
+      const anno = vault.get<AnnotationNormalized>(annoRef);
+      const body = vault.get<any>(anno.body[0]);
+      const service = body?.service?.[0];
+      if (service) {
+        return service.id || service['@id'];
+      }
+    }
+  }
+  return undefined;
+}
+
+// Atlas has no <sequence-panel> element (that lives in iiif-canvas-panel, a
+// layer above this library). This reproduces the same demo - stepping
+// through a manifest's canvases, zooming and rotating - using Atlas's own
+// primitives: a vault-backed manifest load plus AtlasAuto + world-object.
+//
+// It also respects the manifest's IIIF `behavior`: when the manifest
+// declares "paged", canvases are grouped into openings (facing-page
+// spreads) instead of being shown one at a time, honouring per-canvas
+// "non-paged" and the manifest's viewingDirection.
+
+export default { title: 'Sequence Panel' };
+
+const manifestUrl = 'https://iiif.wellcomecollection.org/presentation/b18035723';
+const GUTTER = 40;
+
+// Runtime#getScaleFactor(true) is device pixels per world unit, dpi-
+// adjusted; a world unit is one source-image pixel at that image's own base
+// resolution (see spacial-content/tiled-image.ts -- Atlas always maps 1
+// world unit = 1 pixel of the *full-resolution* source, regardless of which
+// downsampled tile is actually drawn). Once this ratio exceeds 1, the
+// screen has more device pixels to fill than the source has pixels to fill
+// them with, for the *best resolution this IIIF service has* (confirmed via
+// Capture Debug State: the deepest tile's request URL asked for the same
+// width as its own source crop, i.e. no downsampling at all -- there is
+// nothing higher to fetch). Zooming in past that point can only add blur,
+// never detail, so "Zoom In" stops offering to once reached instead of
+// zooming into a regime no tile selection could ever fix.
+const MAX_NATIVE_SCALE_FACTOR = 1;
+
+// Debug fixtures wired up below (WorldObject.debugTileSelection,
+// WorldObject.debugHitTestCulling, CanvasRenderer.debugImageStretch) fire
+// continuously during rendering, not on demand -- there's no "current
+// state" to query, only a stream of events. MAX_DEBUG_EVENTS bounds how
+// many of the most recent ones per fixture are kept around at once so the
+// "Capture Debug State" button below always has something recent to
+// snapshot without the buffers growing unbounded while the story sits idle.
+const MAX_DEBUG_EVENTS = 200;
+
+function pushCapped<T>(buffer: T[], event: T) {
+  buffer.push(event);
+  if (buffer.length > MAX_DEBUG_EVENTS) {
+    buffer.shift();
+  }
+}
+
+// Debug events carry Strand values (Float32Array-backed dna arrays), which
+// JSON.stringify renders as index-keyed objects ("0":1,"1":2,...) rather
+// than readable arrays. Recursively converts any typed array to a plain
+// array before display/logging.
+function serializeDebugValue(value: any): any {
+  if (value && typeof value.length === 'number' && typeof value.BYTES_PER_ELEMENT === 'number') {
+    return Array.from(value as ArrayLike<number>);
+  }
+  if (Array.isArray(value)) {
+    return value.map(serializeDebugValue);
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, any> = {};
+    for (const key of Object.keys(value)) {
+      out[key] = serializeDebugValue(value[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+type Opening = string[];
+
+function computeOpenings(canvasIds: string[], isPaged: boolean, isRightToLeft: boolean, vault: any): Opening[] {
+  if (!isPaged) {
+    return canvasIds.map((id) => [id]);
+  }
+
+  const isNonPaged = (id: string) => {
+    const canvas = vault.get(id) as any;
+    return ((canvas && canvas.behavior) || []).includes('non-paged');
+  };
+
+  const openings: Opening[] = [];
+  let i = 0;
+
+  // The first canvas (e.g. a cover) stands alone unless explicitly paired.
+  if (canvasIds.length && !isNonPaged(canvasIds[0])) {
+    openings.push([canvasIds[0]]);
+    i = 1;
+  }
+
+  while (i < canvasIds.length) {
+    if (isNonPaged(canvasIds[i])) {
+      openings.push([canvasIds[i]]);
+      i += 1;
+    } else if (i + 1 < canvasIds.length && !isNonPaged(canvasIds[i + 1])) {
+      const pair = [canvasIds[i], canvasIds[i + 1]];
+      openings.push(isRightToLeft ? pair.reverse() : pair);
+      i += 2;
+    } else {
+      openings.push([canvasIds[i]]);
+      i += 1;
+    }
+  }
+
+  return openings;
+}
+
+function Container(props: { children: React.ReactNode; style?: any }) {
+  return <div style={{ height: 600, width: '100%', ...(props.style || {}) }}>{props.children}</div>;
+}
+
+type CurrentCanvas = { id: string; imageServiceId: string; width: number; height: number };
+
+type TileLabel = {
+  key: string;
+  index: number;
+  scaleFactor: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  stretched: boolean;
+};
+
+// Mirrors CanvasRenderer.debugTileLoad's status strings 1:1 -- see
+// canvas-renderer.ts's TileLoadDebugEvent. 'requested' that never moves to
+// 'loaded'/'failed' after a few seconds *is* the stuck-request bug: without
+// this, a tile whose network fetch never resolves (or never even gets a
+// proper failure callback -- loadImage previously had no image.onerror
+// handler at all) looks identical on screen to one that's simply still
+// loading normally, with no way to tell "about to finish" from "silently
+// wedged forever".
+const TILE_STATUS_COLORS: Record<TileLoadDebugEvent['status'], string> = {
+  requested: '#f2c94c',
+  loaded: '#4caf50',
+  failed: '#ff4d4d',
+};
+
+// TiledImage.id (see spacial-content/tiled-image.ts) is always
+// `${imageServiceId}--${scaleFactor}` -- splitting on the last `--` recovers
+// which canvas a given ImageStretchDebugEvent's paintId belongs to (to know
+// which world-object to draw its label inside) and which resolution level
+// it's at (several can be on screen at once -- see composite-resource.ts's
+// renderLayers).
+function parsePaintId(paintId: string): { imageServiceId: string; scaleFactor: string } {
+  const separatorIndex = paintId.lastIndexOf('--');
+  if (separatorIndex === -1) {
+    return { imageServiceId: paintId, scaleFactor: '?' };
+  }
+  return { imageServiceId: paintId.slice(0, separatorIndex), scaleFactor: paintId.slice(separatorIndex + 2) };
+}
+
+// Both the HUD list and the debug capture below need to refer to "the same
+// tile" by one shared id -- index/scaleFactor alone (the HUD's "#N@Sx" text)
+// can collide across canvases in a two-page spread, so this folds in the
+// owning canvas too.
+function tileId(imageServiceId: string, index: number, scaleFactor: string): string {
+  return `${imageServiceId}::${index}@${scaleFactor}`;
+}
+
+// Inverts the post-hoc canvas rotation CanvasRenderer#applyTransform applies
+// around the viewport center under rotateFromWorldCenter, so a point
+// computed via Runtime#worldToViewer (which is deliberately rotation-blind,
+// see world-object.ts) can be placed where the content *actually* renders.
+// Forward direction confirmed against applyTransform's own
+// ctx.translate/rotate/translate sequence.
+function rotatePointAroundCenter(x: number, y: number, cx: number, cy: number, angleDeg: number) {
+  const rad = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const dx = x - cx;
+  const dy = y - cy;
+  return { x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos };
+}
+
+export const SequencePanel = () => {
+  const ref = useRef<Preset>();
+  const [openings, setOpenings] = useState<Opening[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [currentCanvases, setCurrentCanvases] = useState<CurrentCanvas[]>([]);
+  const [rotation, setRotation] = useState(0);
+  const [isAtMaxUsefulZoom, setIsAtMaxUsefulZoom] = useState(false);
+  const [capturedDebugState, setCapturedDebugState] = useState<any>(null);
+  // Which tile (see tileId) the HUD list is currently pointing at on
+  // screen, and where -- the tile's *actual* on-screen rect (not a fixed-
+  // size marker, so this honestly shows how much of the image it covers),
+  // cleared on mouse-leave/canvas change. null when nothing's hovered.
+  const [highlightedTile, setHighlightedTile] = useState<{
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    rotation: number;
+    offScreen: boolean;
+  } | null>(null);
+  // Mirrors highlightedTile's source (imageServiceId + label), kept in a
+  // ref so the interval below can recompute the highlight's screen
+  // position every tick while it's active. Without this, panning/zooming
+  // after hovering (including via the Zoom/Rotate buttons, which don't
+  // fire mouseleave) leaves the highlight frozen at its stale, now-wrong
+  // position instead of tracking the tile.
+  const hoveredTileRef = useRef<{ imageServiceId: string; label: TileLabel } | null>(null);
+  // The interval effect below (like nudgeRuntime's own) has an empty
+  // dependency array, so it only ever closes over its *first* render's
+  // functions. nudgeRuntime gets away with that because it only reads
+  // ref.current internally (always fresh); refreshHighlightIfHovering
+  // (defined further down) reads `rotation` state and the canvasXOffsets
+  // memo directly, which would otherwise freeze at their mount-time values
+  // forever. Re-assigned on every render (a plain assignment, not a
+  // useEffect, so it's never a render behind); the interval calls
+  // `.current` instead of the function itself so it always runs the
+  // latest version.
+  const latestRefreshHighlight = useRef<() => void>(() => {});
+  // All currently-tracked tiles' on-screen boxes, redrawn continuously (see
+  // computeAllTileBoxes) so seams/gaps between adjacent tiles are visible
+  // at a glance instead of only one at a time via hover.
+  const [showAllTileBoundaries, setShowAllTileBoundaries] = useState(true);
+  const [allTileBoxes, setAllTileBoxes] = useState<
+    Array<{ id: string; label: string; x: number; y: number; width: number; height: number; offScreen: boolean; status?: TileLoadDebugEvent['status'] }>
+  >([]);
+  // Same "latest ref" reasoning as latestRefreshHighlight.
+  const latestComputeAllTileBoxes = useRef<() => void>(() => {});
+  // Which tile was last clicked in the HUD list -- used to pull that same
+  // tile's entry out of capturedDebugState below, linking the visual list
+  // to the JSON dump.
+  const [selectedTileId, setSelectedTileId] = useState<string | null>(null);
+  // Tile identifiers rendered directly on the canvas, keyed by which
+  // canvas's imageServiceId they belong to -- see parsePaintId. Unlike the
+  // capture buffers below, this isn't reset on capture: a tile's label
+  // should stay put once known, since debugImageStretch only fires again
+  // when that specific tile is *redrawn* (see nudgeRuntime's comment on
+  // the render loop stalling), not merely because it's still on screen.
+  const [tileLabelsByCanvas, setTileLabelsByCanvas] = useState<Record<string, TileLabel[]>>({});
+  // Mirrors tileLabelsByCanvas but updated synchronously and cheaply (no
+  // re-render) every time a tile draws -- see the flush interval below for
+  // why state updates are throttled instead of happening directly here.
+  const tileLabelsRef = useRef<Record<string, TileLabel[]>>({});
+  const tileLabelsDirty = useRef(false);
+  // Keyed by the same tileId as tileLabelsByCanvas/highlightedTile/
+  // selectedTileId, so a HUD row's border color can be looked up directly
+  // by the id it already computes. Same ref-then-flush pattern as
+  // tileLabelsRef/tileLabelsDirty, for the same render-churn reason.
+  const [tileLoadStatus, setTileLoadStatus] = useState<Record<string, TileLoadDebugEvent['status']>>({});
+  const tileLoadStatusRef = useRef<Record<string, TileLoadDebugEvent['status']>>({});
+  const tileLoadStatusDirty = useRef(false);
+  const tileSelectionEvents = useRef<TileSelectionDebugEvent[]>([]);
+  const hitTestCullingEvents = useRef<HitTestCullingDebugEvent[]>([]);
+  const imageStretchEvents = useRef<ImageStretchDebugEvent[]>([]);
+  // Coalesces bursts of scheduleImmediateNudge() calls (many tiles can
+  // finish loading/drawing within the same tick) into a single extra
+  // render() on the next tick, rather than one setTimeout per tile. See
+  // scheduleImmediateNudge's own comment for why this exists at all.
+  const pendingImmediateNudge = useRef(false);
+  // Same "latest ref" reasoning as latestRefreshHighlight above:
+  // scheduleImmediateNudge is called from the debugImageStretch/
+  // debugTileLoad hooks below, which are attached once in a mount-only
+  // effect and would otherwise freeze on whichever function instance
+  // existed at that first render.
+  const latestScheduleImmediateNudge = useRef<() => void>(() => {});
+
+  // Wires up the three debug fixtures (see world-object.ts and
+  // canvas-renderer.ts) for as long as this story is mounted, collecting
+  // into capped buffers rather than reacting per-event -- they fire on
+  // every relevant paint, not on demand, so "capture" below just means
+  // "snapshot whatever's accumulated since the last capture".
+  useEffect(() => {
+    WorldObject.debugTileSelection = (event) => pushCapped(tileSelectionEvents.current, event);
+    WorldObject.debugHitTestCulling = (event) => pushCapped(hitTestCullingEvents.current, event);
+    CanvasRenderer.debugImageStretch = (event) => {
+      pushCapped(imageStretchEvents.current, event);
+
+      const { imageServiceId, scaleFactor } = parsePaintId(event.paintId);
+      const key = `${event.index}@${scaleFactor}`;
+      const label: TileLabel = {
+        key,
+        index: event.index,
+        scaleFactor,
+        x: event.x,
+        y: event.y,
+        width: event.targetWidth,
+        height: event.targetHeight,
+        stretched: event.stretched,
+      };
+      // Written straight to the ref, not React state: while tiles are
+      // streaming in this can fire many times a second, and this story's
+      // AtlasAuto instance already appears to be sensitive to render
+      // churn (see nudgeRuntime's comment) -- setState-per-tile
+      // reliably triggered crashes there. The interval below turns this
+      // into one bounded state update instead of dozens.
+      const existing = tileLabelsRef.current[imageServiceId] || [];
+      tileLabelsRef.current = {
+        ...tileLabelsRef.current,
+        [imageServiceId]: [...existing.filter((l) => l.key !== key), label],
+      };
+      tileLabelsDirty.current = true;
+
+      // A tile's offscreen buffer having just been filled (this hook firing
+      // at all means schedulePaintToCanvas's drawCalls entry for it just
+      // ran, inside *this* render()'s afterFrame -- see nudgeRuntime's
+      // comment on render()/afterFrame() ordering) doesn't mean it's on the
+      // visible canvas yet: paint() already ran earlier in *this* frame,
+      // against the buffer as it was before this fill. It takes one more
+      // render() call for paint() to draw the now-ready buffer. Left to the
+      // regular 400ms interval, that's up to ~400ms of visible staleness on
+      // top of however long the fetch itself took.
+      latestScheduleImmediateNudge.current();
+    };
+    CanvasRenderer.debugTileLoad = (event) => {
+      const { imageServiceId } = parsePaintId(event.paintId);
+      const key = tileId(imageServiceId, event.index, String(event.scale));
+      tileLoadStatusRef.current = { ...tileLoadStatusRef.current, [key]: event.status };
+      tileLoadStatusDirty.current = true;
+
+      // 'loaded' means the network fetch just finished -- schedulePaintToCanvas
+      // has queued the buffer-fill drawCall, but it won't actually run until
+      // the next afterFrame(), i.e. the next render(). Nudging here gets
+      // that fill (and the debugImageStretch nudge above, for the draw
+      // after it) moving as soon as possible instead of waiting on the
+      // interval, closing both halves of the gap.
+      if (event.status === 'loaded') {
+        latestScheduleImmediateNudge.current();
+      }
+    };
+    return () => {
+      WorldObject.debugTileSelection = undefined;
+      WorldObject.debugHitTestCulling = undefined;
+      CanvasRenderer.debugImageStretch = undefined;
+      CanvasRenderer.debugTileLoad = undefined;
+    };
+  }, []);
+
+  // Runtime.render() -- the requestAnimationFrame-driven frame function,
+  // which does getAllPointsAt selection, kicks off getScheduledUpdates,
+  // pumps CanvasRenderer's draw-call queue, *and* iterates the resulting
+  // Paint entries through renderer.paint()/prepareLayer()/finishLayer()
+  // (which is what actually updates OverlayRenderer's DOM for Text/
+  // <paragraph> elements -- CompositeRenderer.getPointsAt alone only
+  // resolves *which* content is in view, it doesn't paint any of it) --
+  // reliably stops looping after its first few frames in this dev
+  // environment (confirmed by instrumenting runtime.ts directly --
+  // unrelated to these hooks, and a bigger issue than this story should
+  // try to fix). Rotating/zooming still visibly repaints once via other
+  // paths, but there's no guarantee any of the above has run recently
+  // enough to reflect the current view.
+  //
+  // Calling runtime.render() directly, forcing pendingUpdate first so its
+  // own early-return gate doesn't just no-op, runs the real pipeline
+  // instead of hand-reimplementing pieces of it here (which is what an
+  // earlier version of this function did, and which turned out to miss
+  // the paint-iteration step above entirely -- tile images painted, but
+  // the labels never did). It's the same call the RAF loop itself makes.
+  const nudgeRuntime = () => {
+    // This fires from setTimeout/setInterval, by which point this specific
+    // AtlasAuto/Runtime may already have been torn down and replaced by a
+    // new one (the multiple-renderers instability itself). Calling into a
+    // half-torn-down runtime's internals throws and takes the whole story
+    // down with it. Since this is inherently a best-effort "if there's
+    // fresh work to do, do it" nudge and not required for anything else to
+    // function, swallowing that failure here is the correct trade-off --
+    // the next tick gets another chance.
+    try {
+      const preset = ref.current;
+      const runtime = preset?.runtime;
+      if (!runtime) return;
+
+      runtime.pendingUpdate = true;
+      runtime.render(performance.now());
+
+      // getObjectsAt (hit-testing) isn't part of the passive render loop --
+      // it's normally only invoked in response to real pointer events -- so
+      // it still needs to be triggered manually to populate hitTestCulling.
+      // The viewport center is as representative a sample point as any for
+      // "is anything hit-testable right now".
+      const cx = (runtime.target[1] + runtime.target[3]) / 2;
+      const cy = (runtime.target[2] + runtime.target[4]) / 2;
+      runtime.world.getObjectsAt(dna([1, cx, cy, cx + 1, cy + 1]), true);
+
+      // Keeps the Zoom In button's disabled state honest across pan/zoom/
+      // resize -- see MAX_NATIVE_SCALE_FACTOR's comment.
+      setIsAtMaxUsefulZoom(runtime.getScaleFactor(true) >= MAX_NATIVE_SCALE_FACTOR);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('Sequence Panel: skipped a runtime nudge (likely a stale/torn-down runtime)', err);
+    }
+  };
+
+  // Runs one more nudgeRuntime() on the next tick (not synchronously --
+  // see below) rather than waiting for the 400ms interval. Called from the
+  // debugTileLoad/debugImageStretch hooks above to close the two-step gap
+  // documented on each: a tile becoming ready is not the same render() call
+  // as it becoming visible, and this story's render loop otherwise only
+  // advances on a fixed timer.
+  //
+  // Deliberately setTimeout(...,0), not a direct call: debugImageStretch
+  // fires *from inside* afterFrame(), itself called from inside render() --
+  // calling nudgeRuntime() (which calls render() again) synchronously from
+  // there would re-enter render() while it's still on the call stack.
+  // Deferring a tick means the current render() call finishes first, and
+  // (since debugImageStretch's own handler calls this too) still ends up
+  // running a second nudge immediately after -- back-to-back, but not
+  // nested.
+  const scheduleImmediateNudge = () => {
+    if (pendingImmediateNudge.current) return;
+    pendingImmediateNudge.current = true;
+    setTimeout(() => {
+      pendingImmediateNudge.current = false;
+      nudgeRuntime();
+    }, 0);
+  };
+  latestScheduleImmediateNudge.current = scheduleImmediateNudge;
+
+  // A tile can finish loading (network) well after the nudge that kicked it
+  // off has returned -- render() only *queues* the resulting draw call at
+  // that point. Nudging continuously, independent of nudgeSoon, is what
+  // actually gets it (and its label) on screen close to when it's ready,
+  // rather than only at the next explicit interaction. Same interval also
+  // flushes the tile-label state batch (see tileLabelsDirty above).
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      nudgeRuntime();
+      latestRefreshHighlight.current();
+      latestComputeAllTileBoxes.current();
+      if (tileLabelsDirty.current) {
+        tileLabelsDirty.current = false;
+        setTileLabelsByCanvas(tileLabelsRef.current);
+      }
+      if (tileLoadStatusDirty.current) {
+        tileLoadStatusDirty.current = false;
+        setTileLoadStatus(tileLoadStatusRef.current);
+      }
+    }, 400);
+    return () => window.clearInterval(intervalId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const captureDebugState = () => {
+    nudgeRuntime();
+
+    // Drop tiles that aren't currently on screen (isVisible: false -- e.g. a
+    // slow-loading tile that finished after the view moved on) before
+    // display: a stretched tile nobody can currently see isn't actionable,
+    // and just adds noise to what's meant to be a "what's wrong right now"
+    // snapshot.
+    const visibleImageStretchEvents = imageStretchEvents.current.filter((event) => event.isVisible);
+    // Re-derive `stretched` here via isImageStretched directly, rather than
+    // trusting each event's precomputed field -- keeps this view honest
+    // about exactly what it's flagging and why, straight from the same
+    // aspect-ratio comparison canvas-renderer.ts uses.
+    const stretchedVisibleEvents = visibleImageStretchEvents.filter((event) =>
+      isImageStretched(event.naturalWidth, event.naturalHeight, event.targetWidth, event.targetHeight)
+    );
+
+    // Tags each entry with the same id the HUD list uses (see tileId) --
+    // this is the actual link between a label the user clicked/hovered and
+    // its entry here, rather than making them separately re-derive it from
+    // paintId/index the way the HUD does.
+    const imageStretchWithIds = visibleImageStretchEvents.map((event) => {
+      const { imageServiceId, scaleFactor } = parsePaintId(event.paintId);
+      return { tileId: tileId(imageServiceId, event.index, scaleFactor), label: `#${event.index}@${scaleFactor}x`, ...event };
+    });
+
+    const snapshot = {
+      capturedAt: new Date().toISOString(),
+      rotation,
+      currentIndex,
+      tileSelection: serializeDebugValue(tileSelectionEvents.current),
+      hitTestCulling: serializeDebugValue(hitTestCullingEvents.current),
+      imageStretch: serializeDebugValue(imageStretchWithIds),
+      hiddenNotVisibleCount: imageStretchEvents.current.length - visibleImageStretchEvents.length,
+      stretchedTileCount: stretchedVisibleEvents.length,
+    };
+    // Buffers reflect activity *since the last capture* going forward.
+    tileSelectionEvents.current = [];
+    hitTestCullingEvents.current = [];
+    imageStretchEvents.current = [];
+    // eslint-disable-next-line no-console
+    console.log('Sequence Panel debug fixture capture', snapshot);
+    setCapturedDebugState(snapshot);
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { vault } = getVaultHelper();
+      const manifest = await vault.loadManifest(manifestUrl);
+      if (cancelled || !manifest) return;
+
+      const canvasIds = (manifest.items || []).map((canvasRef: any) => canvasRef.id);
+      const isPaged = (manifest.behavior || []).includes('paged');
+      const isRightToLeft = manifest.viewingDirection === 'right-to-left';
+
+      setOpenings(computeOpenings(canvasIds, isPaged, isRightToLeft, vault));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const opening = openings[currentIndex];
+    if (!opening) return;
+
+    const { vault } = getVaultHelper();
+    const canvases = opening
+      .map((canvasId) => {
+        const canvas = vault.get<CanvasNormalized>(canvasId);
+        const imageServiceId = getCanvasImageServiceId(canvas, vault);
+        if (!imageServiceId) return null;
+        return { id: canvasId, imageServiceId, width: canvas.width, height: canvas.height };
+      })
+      .filter((c): c is CurrentCanvas => c !== null);
+
+    setCurrentCanvases(canvases);
+  }, [openings, currentIndex]);
+
+  const previousOpening = () => setCurrentIndex((i) => Math.max(i - 1, 0));
+  const nextOpening = () => setCurrentIndex((i) => Math.min(i + 1, openings.length - 1));
+
+  // Any interaction that changes what should be on screen needs its own
+  // nudge afterward -- see nudgeRuntime's comment. Two delayed calls: one
+  // to pick up the new viewport/rotation once the transition has mostly
+  // settled, a second to catch tiles that were still loading after the
+  // first (each nudge's getScheduledUpdates can itself surface more work).
+  const nudgeSoon = () => {
+    setTimeout(nudgeRuntime, 350);
+    setTimeout(nudgeRuntime, 900);
+  };
+
+  // Covers initial load and Prev/Next-driven canvas changes -- both mount a
+  // new AtlasAuto/world-object rather than going through a click handler
+  // above, so they need their own nudge to get tiles loading and labelled
+  // without the user having to interact first.
+  useEffect(() => {
+    if (currentCanvases.length) {
+      nudgeSoon();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentCanvases]);
+
+  // A hover/selection from a previous opening pointing at content that no
+  // longer exists would be actively misleading, not just stale.
+  useEffect(() => {
+    hoveredTileRef.current = null;
+    setHighlightedTile(null);
+    setSelectedTileId(null);
+    setAllTileBoxes([]);
+  }, [currentIndex]);
+
+  // Each canvas's world-object is offset by this much (see the render loop
+  // below) to lay a spread out left-to-right -- computed once per
+  // currentCanvases change so both the render loop and the hover handler
+  // agree on where a given canvas actually sits, instead of duplicating the
+  // running-total logic in two places.
+  const canvasXOffsets = React.useMemo(() => {
+    const offsets: Record<string, number> = {};
+    let x = 0;
+    for (const canvas of currentCanvases) {
+      offsets[canvas.imageServiceId] = x;
+      x += canvas.width + GUTTER;
+    }
+    return offsets;
+  }, [currentCanvases]);
+
+  // Maps a tile's own local x/y/width/height (as recorded from
+  // debugImageStretch) to where it actually renders on screen right now.
+  //
+  // event.x/y/targetWidth/targetHeight are TiledImage#display.points, which
+  // is deliberately data.points, not data.displayPoints (see
+  // spacial-content/tiled-image.ts's constructor) -- i.e. pixels local to
+  // that *specific downsampled tile*, not the shared full-resolution world
+  // space every other Atlas coordinate (world-object x/y/width/height,
+  // canvasXOffsets, worldToViewer's inputs) uses. A tile at scaleFactor 4 is
+  // stored at 1/4 those pixel counts, so world coordinates are exactly
+  // label.{x,y,width,height} * scaleFactor -- confirmed against a captured
+  // "whole image at 4x" tile: targetWidth 643 * 4 = 2572, matching the
+  // canvas's real ~2569px width (rounding from the /4 in TiledImage). Skipping
+  // this multiply is what made a tile that actually covers the whole image
+  // highlight as a small fraction of it.
+  //
+  // Shared by the single hover highlight and the "show all tile boundaries"
+  // overlay below -- both need exactly this same on-screen rect, just for
+  // different sets of tiles and with different rendering on top.
+  const computeTileScreenBox = (imageServiceId: string, label: TileLabel) => {
+    const preset = ref.current;
+    const runtime = preset?.runtime;
+    const canvasEl = preset?.canvas;
+    if (!runtime || !canvasEl) return null;
+
+    const tileScaleFactor = parseFloat(label.scaleFactor) || 1;
+    const worldX = label.x * tileScaleFactor;
+    const worldY = label.y * tileScaleFactor;
+    const worldWidth = label.width * tileScaleFactor;
+    const worldHeight = label.height * tileScaleFactor;
+
+    const globalX = (canvasXOffsets[imageServiceId] || 0) + worldX;
+    const screenRect = runtime.worldToViewer(globalX, worldY, worldWidth, worldHeight);
+    const centerX = screenRect.x + screenRect.width / 2;
+    const centerY = screenRect.y + screenRect.height / 2;
+    const center = rotation
+      ? rotatePointAroundCenter(centerX, centerY, canvasEl.clientWidth / 2, canvasEl.clientHeight / 2, rotation)
+      : { x: centerX, y: centerY };
+
+    // A tile that covered the whole view when it was drawn (e.g. a low-res
+    // overview fetched right after load) can end up far larger than the
+    // current viewport after zooming in -- its highlight is then mostly or
+    // entirely clipped by the container's overflow:hidden. Flagging that
+    // (checked against the *unrotated* rect, an approximation once rotated,
+    // but good enough to tell "mostly here" from "elsewhere entirely") lets
+    // the UI say so instead of just silently showing a sliver.
+    const left = screenRect.x;
+    const top = screenRect.y;
+    const offScreen =
+      left < 0 || top < 0 || left + screenRect.width > canvasEl.clientWidth || top + screenRect.height > canvasEl.clientHeight;
+
+    return {
+      x: center.x,
+      y: center.y,
+      // The tile's real on-screen size, not a fixed/clamped marker -- shows
+      // honestly how much of the image it actually covers at the current
+      // zoom, and how that compares to its neighbours. The box is centered
+      // on `center` (already rotation-corrected) and then CSS-rotated by the
+      // same amount around its own center (== center, by construction),
+      // which correctly rotates its *shape* to match -- worldToViewer's
+      // unrotated width/height are still the right numbers to rotate, since
+      // rotation doesn't change a rectangle's own dimensions, only its
+      // position and orientation.
+      width: screenRect.width,
+      height: screenRect.height,
+      offScreen,
+    };
+  };
+
+  const highlightTile = (imageServiceId: string, label: TileLabel) => {
+    const box = computeTileScreenBox(imageServiceId, label);
+    if (!box) return;
+    setHighlightedTile({ id: tileId(imageServiceId, label.index, label.scaleFactor), rotation, ...box });
+  };
+
+  // One outline per currently-tracked tile (see tileLabelsByCanvas), drawn
+  // directly on the canvas at all times rather than only on hover -- lets a
+  // seam or gap between adjacent tiles (e.g. a coarser tile still showing
+  // through a thin strip its neighbour doesn't quite cover) show up
+  // directly, instead of having to hover them one at a time and compare by
+  // eye/memory. Colored by the same network-load status as the HUD rows.
+  // Skips fully off-screen tiles (huge stale overview tiles from early in
+  // this canvas's load, mostly) purely to keep the overlay legible.
+  const computeAllTileBoxes = () => {
+    if (!showAllTileBoundaries) return;
+    const canvasEl = ref.current?.canvas;
+    if (!canvasEl) return;
+    const boxes: Array<{ id: string; label: string; x: number; y: number; width: number; height: number; offScreen: boolean; status?: TileLoadDebugEvent['status'] }> = [];
+    for (const canvas of currentCanvases) {
+      const labels = tileLabelsByCanvas[canvas.imageServiceId] || [];
+      for (const label of labels) {
+        const box = computeTileScreenBox(canvas.imageServiceId, label);
+        if (!box) continue;
+        // box.offScreen (from computeTileScreenBox) means "not *fully*
+        // visible" -- right for the single hover highlight's warning
+        // banner, but wrong here: at a deep enough zoom every tracked tile
+        // is individually bigger than the viewport, so *every* box would
+        // have offScreen: true and this overlay would render nothing at
+        // all. What actually matters for "is this worth drawing" is
+        // whether it overlaps the canvas *at all*.
+        const left = box.x - box.width / 2;
+        const top = box.y - box.height / 2;
+        const noOverlap = left + box.width < 0 || top + box.height < 0 || left > canvasEl.clientWidth || top > canvasEl.clientHeight;
+        if (noOverlap) continue;
+        const id = tileId(canvas.imageServiceId, label.index, label.scaleFactor);
+        boxes.push({ id, label: `#${label.index}@${label.scaleFactor}x`, status: tileLoadStatus[id], ...box });
+      }
+    }
+    setAllTileBoxes(boxes);
+  };
+  latestComputeAllTileBoxes.current = computeAllTileBoxes;
+
+  // Keeps a hovered highlight tracking its tile through zoom/pan/rotation
+  // that happens without the mouse ever leaving the row (e.g. via the
+  // Zoom/Rotate buttons) -- otherwise it freezes at its position from the
+  // moment of hover, which very quickly reads as "wrong" rather than
+  // "stale". Reuses the same interval as nudgeRuntime/tile-label flushing
+  // rather than adding a second timer.
+  const refreshHighlightIfHovering = () => {
+    if (hoveredTileRef.current) {
+      highlightTile(hoveredTileRef.current.imageServiceId, hoveredTileRef.current.label);
+    }
+  };
+  latestRefreshHighlight.current = refreshHighlightIfHovering;
+
+    const sleep = (ms: number | undefined) => new Promise(resolve => setTimeout(resolve, ms));
+
+
+    const setupTest2 = async () => {
+      const runtime = ref.current?.runtime;
+      await setupTest();
+      simulateDrag(false, 300)
+      await sleep(1000);
+      simulateDrag(false, 300)
+      await sleep(500);
+    }
+
+    const setupTest = async () => {
+      const runtime = ref.current?.runtime;
+
+      nextOpening(); 
+      nudgeSoon();
+      setRotation((r) => (r + 90) % 360);
+      nudgeSoon();
+      runtime?.world.zoomIn();
+      nudgeSoon();
+      nudgeSoon();
+      runtime?.world.zoomIn();
+      await sleep(500);
+      nudgeSoon();
+      nudgeSoon();
+      runtime?.world.zoomIn();
+      await sleep(500);
+      nudgeSoon();
+      nudgeSoon();
+      runtime?.world.zoomIn();
+      await sleep(500);
+      nudgeSoon();
+      nudgeSoon();
+      runtime?.world.zoomIn();
+      await sleep(500);
+      nudgeSoon();
+      nudgeSoon();
+      runtime?.world.zoomIn();
+      await sleep(500);
+      nudgeSoon();
+      runtime?.world.zoomIn();
+      nudgeSoon();
+    }
+
+  // Drives the canvas with synthetic mouse events (mousedown -> several
+  // mousemoves stepping left -> mouseup), to reproduce the rotate-then-drag
+  // jump bug deterministically from a button click rather than a manual
+  // mouse drag. Dispatches both Pointer and Mouse events on every step --
+  // browser-event-manager listens for both, and the two mouse-move
+  // strategies inside it (see popmotion-controller.ts /
+  // browser-event-manager.ts) key off different event types.
+  //
+  // Each mousemove gets its own macrotask (via setTimeout, not a tight
+  // synchronous loop): browser-event-manager's _realPointerMove just
+  // records `this.pointerMoveEvent = e` and a separate simulation-rate tick
+  // is what actually drains it into onPointerMove -- firing all the moves
+  // back-to-back synchronously means every one but the last gets
+  // overwritten before that tick ever runs, so the runtime only ever sees
+  // a single jump straight to the final position instead of a real drag.
+  const simulateDrag = (left = true, size = 150) => {
+    const canvasEl = ref.current?.canvas;
+    if (!canvasEl) return;
+
+    const rect = canvasEl.getBoundingClientRect();
+    const startX = rect.left + rect.width / 2;
+    const startY = rect.top + rect.height / 2;
+    const distance = size * (left? 1 : -1);
+    const steps = 15;
+    const stepDelayMs = 30;
+
+    const fire = (type: 'mousedown' | 'mousemove' | 'mouseup', x: number, y: number) => {
+      const isUp = type === 'mouseup';
+      const opts: PointerEventInit & MouseEventInit = {
+        clientX: x,
+        clientY: y,
+        bubbles: true,
+        cancelable: true,
+        pointerId: 1,
+        button: 0,
+        buttons: isUp ? 0 : 1,
+        isPrimary: true,
+      };
+      const pointerType = type.replace('mouse', 'pointer') as 'pointerdown' | 'pointermove' | 'pointerup';
+      canvasEl.dispatchEvent(new PointerEvent(pointerType, opts));
+      canvasEl.dispatchEvent(new MouseEvent(type, opts));
+    };
+
+    fire('mousedown', startX, startY);
+
+    for (let i = 1; i <= steps; i++) {
+      window.setTimeout(() => {
+        const x = startX - (distance * i) / steps;
+        fire('mousemove', x, startY);
+      }, stepDelayMs * i);
+    }
+
+    // Let the throttled move actually get processed before releasing.
+    window.setTimeout(() => {
+      fire('mouseup', startX - distance, startY);
+    }, stepDelayMs * steps + 100);
+  };
+
+  return (
+    <>
+      <button
+        disabled={currentIndex === 0}
+        onClick={() => {
+          previousOpening();
+          nudgeSoon();
+        }}
+      >
+        Prev
+      </button>
+      <button
+        disabled={currentIndex >= openings.length - 1}
+        onClick={() => {
+          nextOpening();
+          nudgeSoon();
+        }}
+      >
+        Next
+      </button>
+      <button
+        disabled={isAtMaxUsefulZoom}
+        onClick={() => {
+          const runtime = ref.current?.runtime;
+          // getScaleFactor(true) is device-pixel-per-world-unit (dpi-
+          // adjusted); world units are source-image pixels at that
+          // canvas's own base resolution (see spacial-content/tiled-
+          // image.ts), so once this passes 1 there are more screen pixels
+          // than source pixels to show, and it can only get blurrier from
+          // there -- see MAX_NATIVE_SCALE_FACTOR's comment.
+          if (runtime && runtime.getScaleFactor(true) >= MAX_NATIVE_SCALE_FACTOR) {
+            return;
+          }
+          runtime?.world.zoomIn();
+          nudgeSoon();
+        }}
+      >
+        Zoom In
+      </button>
+      <button
+        onClick={() => {
+          ref.current?.runtime?.world.zoomOut();
+          nudgeSoon();
+        }}
+      >
+        Zoom Out
+      </button>
+      <button
+        onClick={() => {
+          setRotation((r) => (r + 90) % 360);
+          nudgeSoon();
+        }}
+      >
+        Rotate Canvas From Center
+      </button>
+      <button onClick={setupTest}>setup test</button>
+      <button onClick={setupTest2}>setup test2</button>
+      <button onClick={captureDebugState}>Capture Debug State</button>
+      <button onClick={simulateDrag}>Simulate Drag 150px Left</button>
+      <button
+        onClick={() => {
+          setShowAllTileBoundaries((show) => {
+            const next = !show;
+            if (next) computeAllTileBoxes();
+            else setAllTileBoxes([]);
+            return next;
+          });
+        }}
+      >
+        {showAllTileBoundaries ? 'Hide' : 'Show'} All Tile Boundaries
+      </button>
+
+      <div style={{ fontSize: 11, fontFamily: 'monospace', margin: '4px 0', opacity: 0.8 }}>
+        tile border:{' '}
+        {(Object.keys(TILE_STATUS_COLORS) as Array<TileLoadDebugEvent['status']>).map((status) => (
+          <span key={status} style={{ marginRight: 10 }}>
+            <span
+              style={{
+                display: 'inline-block',
+                width: 8,
+                height: 8,
+                border: `2px solid ${TILE_STATUS_COLORS[status]}`,
+                borderRadius: 2,
+                marginRight: 4,
+              }}
+            />
+            {status}
+          </span>
+        ))}
+      </div>
+
+      <div style={{ position: 'relative', overflow: 'hidden' }}>
+        <Container>
+          {currentCanvases.length ? (
+            <AtlasAuto
+              rotateFromWorldCenter
+              onCreated={(e) => {
+                ref.current = e;
+                // Debug convenience only: lets a browser console (or an
+                // automated test) drive runtime.target/goHome directly to
+                // reach a specific tile for inspection, without fighting
+                // simulated mouse drags to pan there.
+                (window as any).__atlasPreset = e;
+              }}
+            >
+              <world>
+                {currentCanvases.map((canvas) => (
+                  <world-object
+                    key={canvas.id}
+                    x={canvasXOffsets[canvas.imageServiceId] || 0}
+                    height={canvas.height}
+                    width={canvas.width}
+                  >
+                    <ImageService id={canvas.imageServiceId} width={canvas.width} height={canvas.height} rotation={rotation} />
+                  </world-object>
+                ))}
+              </world>
+            </AtlasAuto>
+          ) : null}
+        </Container>
+
+        {/* Every currently-tracked, on-screen tile's own boundary -- see
+            computeAllTileBoxes. Unlike the single hover highlight below,
+            these are unfilled (border only) so overlapping tiles at
+            different resolution levels are all still visible, and a real
+            seam/gap between neighbouring tiles shows up directly as a
+            visible line instead of having to hover each one and compare. */}
+        {showAllTileBoundaries
+          ? allTileBoxes.map((box) => (
+              <div
+                key={box.id}
+                title={`${box.label} -- ${box.status || 'unknown'}`}
+                style={{
+                  position: 'absolute',
+                  left: box.x - box.width / 2,
+                  top: box.y - box.height / 2,
+                  width: box.width,
+                  height: box.height,
+                  transform: `rotate(${rotation}deg)`,
+                  boxSizing: 'border-box',
+                  zIndex: 15,
+                  border: `1px solid ${box.status ? TILE_STATUS_COLORS[box.status] : '#555'}`,
+                  pointerEvents: 'none',
+                }}
+              />
+            ))
+          : null}
+
+        {/* Marks where the hovered HUD row's tile actually is right now --
+            see highlightTile. Not clipped to the canvas bounds: if the tile
+            is currently panned off screen, this deliberately renders
+            outside Container too, which is the honest answer to "where is
+            it" (nowhere visible) rather than hiding that fact. */}
+        {highlightedTile ? (
+          <div
+            style={{
+              position: 'absolute',
+              left: highlightedTile.x - highlightedTile.width / 2,
+              top: highlightedTile.y - highlightedTile.height / 2,
+              width: highlightedTile.width,
+              height: highlightedTile.height,
+              // The box is already centered on the rotation-corrected
+              // center point (see highlightTile), so CSS's default
+              // transform-origin (50% 50%, i.e. this box's own center)
+              // rotates its shape around exactly that same point -- no
+              // extra transform-origin math needed.
+              transform: `rotate(${highlightedTile.rotation}deg)`,
+              boxSizing: 'border-box',
+              zIndex: 20,
+              border: '3px solid #ffd23f',
+              boxShadow: '0 0 0 2px rgba(0,0,0,0.6), 0 0 12px rgba(255,210,63,0.8)',
+              borderRadius: 4,
+              pointerEvents: 'none',
+            }}
+          />
+        ) : null}
+
+        {highlightedTile?.offScreen ? (
+          <div
+            style={{
+              position: 'absolute',
+              left: 8,
+              bottom: 8,
+              zIndex: 20,
+              background: 'rgba(0,0,0,0.75)',
+              color: '#ffd23f',
+              fontSize: 11,
+              fontFamily: 'monospace',
+              padding: '4px 8px',
+              borderRadius: 4,
+              pointerEvents: 'none',
+            }}
+          >
+            tile extends beyond the current view -- zoom/pan to see all of it
+          </div>
+        ) : null}
+
+        {/* Tile labels used to be Atlas <paragraph> elements positioned in
+            world space, attached to their tile. That meant they panned and
+            zoomed with the content -- which also meant panning away made
+            them disappear entirely, and zooming out shrank them below
+            legibility (there's no way to keep a world-space element at a
+            constant screen size). Plain HTML positioned over the canvas,
+            outside Atlas's coordinate system entirely, stays fixed on
+            screen and legible regardless of pan/zoom. Hovering a row
+            instead draws the highlight above at the tile's *current*
+            on-screen position, and clicking one links it to its entry in
+            the debug capture below (see selectedTileId). */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 8,
+            right: 8,
+            // Atlas's own root element sets --atlas-z-index (default 10) on
+            // itself (see utility/stylesheet.ts's base rules) -- without
+            // out-ranking that here, this panel renders correctly into the
+            // DOM (confirmed) but sits underneath the canvas, invisible.
+            zIndex: 20,
+            maxHeight: 'calc(100% - 16px)',
+            maxWidth: 220,
+            overflowY: 'auto',
+            background: 'rgba(0,0,0,0.75)',
+            color: '#fff',
+            fontSize: 11,
+            fontFamily: 'monospace',
+            padding: 8,
+            borderRadius: 4,
+          }}
+        >
+          {currentCanvases.map((canvas) => {
+            const labels = tileLabelsByCanvas[canvas.imageServiceId] || [];
+            if (!labels.length) return null;
+            return (
+              <div key={canvas.id} style={{ marginBottom: 6 }}>
+                <div style={{ opacity: 0.7, marginBottom: 2 }}>{canvas.id.split('/').pop()}</div>
+                {labels.map((label) => {
+                  const id = tileId(canvas.imageServiceId, label.index, label.scaleFactor);
+                  const isSelected = selectedTileId === id;
+                  // No entry yet means debugTileLoad hasn't fired for this
+                  // tile at all -- e.g. it was drawn straight from
+                  // imageCache (see canvas-renderer.ts's loadImage) before
+                  // this hook existed in this session, or before this
+                  // effect mounted. Distinguished from 'requested' (in
+                  // flight) with a neutral color rather than implying
+                  // either state.
+                  const status = tileLoadStatus[id];
+                  const statusColor = status ? TILE_STATUS_COLORS[status] : '#555';
+                  return (
+                    <div
+                      key={label.key}
+                      onMouseEnter={() => {
+                        hoveredTileRef.current = { imageServiceId: canvas.imageServiceId, label };
+                        highlightTile(canvas.imageServiceId, label);
+                      }}
+                      onMouseLeave={() => {
+                        hoveredTileRef.current = null;
+                        setHighlightedTile(null);
+                      }}
+                      onClick={() => {
+                        setSelectedTileId(id);
+                        captureDebugState();
+                      }}
+                      title={status ? `network: ${status}` : 'network: unknown (loaded before debugTileLoad attached)'}
+                      style={{
+                        color: label.stretched ? '#ff6b6b' : '#fff',
+                        cursor: 'pointer',
+                        textDecoration: isSelected ? 'underline' : 'none',
+                        background: isSelected ? 'rgba(255,210,63,0.25)' : 'transparent',
+                        border: `1px solid ${statusColor}`,
+                        borderRadius: 3,
+                        padding: '0 3px',
+                        marginBottom: 1,
+                      }}
+                    >
+                      #{label.index}@{label.scaleFactor}x{label.stretched ? ' (stretched)' : ''}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {capturedDebugState ? (
+        <>
+          <div>
+            Captured at {capturedDebugState.capturedAt} -- {capturedDebugState.tileSelection.length} tile-selection,{' '}
+            {capturedDebugState.hitTestCulling.length} hit-test, {capturedDebugState.imageStretch.length} visible
+            image-draw events ({capturedDebugState.stretchedTileCount} stretched, {capturedDebugState.hiddenNotVisibleCount}{' '}
+            hidden as not currently visible)
+          </div>
+
+          {selectedTileId
+            ? (() => {
+                // The actual link from a clicked HUD label to this JSON:
+                // both were tagged with the same tileId (see
+                // captureDebugState and the HUD row's onClick above).
+                const match = capturedDebugState.imageStretch.find((entry: any) => entry.tileId === selectedTileId);
+                return (
+                  <div style={{ border: '2px solid #ffd23f', borderRadius: 4, padding: 8, margin: '8px 0', background: '#1a1a1a' }}>
+                    <strong>{selectedTileId}</strong>
+                    {match ? (
+                      <div style={{ fontSize: 12, marginTop: 4 }}>
+                        <div>
+                          natural {match.naturalWidth}x{match.naturalHeight} -- target {match.targetWidth}x
+                          {match.targetHeight}
+                        </div>
+                        <div>
+                          stretched: {String(match.stretched)}, visible: {String(match.isVisible)}
+                        </div>
+                        <div style={{ opacity: 0.7, wordBreak: 'break-all', marginTop: 2 }}>{match.url}</div>
+                      </div>
+                    ) : (
+                      <div style={{ fontSize: 12, marginTop: 4, opacity: 0.7 }}>
+                        Not in this capture (it may not have been (re)drawn since the last click) -- click the label
+                        again to refresh.
+                      </div>
+                    )}
+                  </div>
+                );
+              })()
+            : null}
+
+          <pre style={{ maxHeight: 300, overflow: 'auto', background: '#111', color: '#0f0', padding: 8, fontSize: 11 }}>
+            {JSON.stringify(capturedDebugState, null, 2)}
+          </pre>
+        </>
+      ) : null}
+    </>
+  );
+};

--- a/stories/sequence-panel.stories.tsx
+++ b/stories/sequence-panel.stories.tsx
@@ -739,7 +739,9 @@ export const SequencePanel = () => {
 
       nextOpening(); 
       nudgeSoon();
+      await sleep(1000);
       setRotation((r) => (r + 90) % 360);
+      await sleep(1000);
       nudgeSoon();
       runtime?.world.zoomIn();
       nudgeSoon();

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -9,7 +9,7 @@ export default defineConfig((options) => ({
   entry: {
     index: 'src/index.ts',
   },
-  minify: !options.watch,
+  minify: options.watch ? false : { compress: true, mangle: false, codegen: true },
   clean: true,
   external: ['react', 'react-dom', 'scheduler', 'react-reconciler'],
   globalName: 'AtlasViewer',


### PR DESCRIPTION
With the help of `Claude`, I've tried to fix a number of issues around rotation to enable rotation around the center of the viewport instead of the center of the image.  I tried to focus on two general use-cases (a single canvas, and the sequence panel (facing canvases).  I also tried to address a few common issues:
- dragging
- rendering all times
- making sure the bounce-back when dragging outside of the world boundaries works as expected
- making sure zooming continues to work
- making sure that pop-motion behaviors are working as expected
- conformance with CanvasPanel 2.0 v2

A bunch of additional debug fixtures and test cases were added to try and make sure that the movements conform to the expected behaviors. I also added some debug states to the Tile(s) which might be worth keeping or removing. Lastly 